### PR TITLE
docs: cora 2-BM sync + add detector Z-rail alignment procedure

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1164,6 +1164,17 @@ rotate axes ``2bmb:table3.X``, ``.Y``, ``.Z``, ``.AX``, ``.AY``,
    and Rotate columns are calc-driven composites; the Motors column
    shows the six underlying motor records listed above.
 
+.. note::
+
+   **Procedure that commands this table.**
+   :doc:`../procedures/item_002` (``detector_z_rail_alignment``)
+   uses ``2bmb:table3.AX`` (pitch) and ``.AY`` (yaw) to rotate the
+   Optique Peter Z rail back parallel to the beam after a small
+   square X-ray spot is observed to drift across the camera as the
+   Z stage translates. This is the procedure that justifies
+   registering an ``OpticalTable`` Family + ``Detector_optical_table``
+   Asset on the cora side.
+
 
 Trigger and synchronisation
 ===========================

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -369,12 +369,13 @@ Y3-30 Mirror
 
 :Role: Vertical-deflecting mirror; defines the alternate beam centrelines
 :Family: Mirror
-   (Pending in cora: Asset ``Mirror_2BM`` appears in the
-   Pending table at ``docs/deployments/2-bm/assets.md`` and Family
-   ``Mirror`` is listed as "Pending in code" at
-   ``docs/catalog/families.md``. Composes a mirror body with an
-   in-vacuum stripe selector and an external optical-table sub-
-   assembly carrying Y / X / Z stages.)
+   (Pending in cora: Asset ``Y3-30_mirror`` appears in the
+   Pending table at ``docs/deployments/2-bm/assets.md`` (renamed
+   from ``Mirror_2BM`` per cora's #89) and Family ``Mirror`` is
+   listed as "Pending in code" at ``docs/catalog/families.md``.
+   Composes a mirror body with an in-vacuum stripe selector and
+   an external optical-table sub-assembly carrying Y / X / Z
+   stages.)
 :Mounted on: Optical table (``[Dma:table1]`` via the ``table_full`` IOC)
 :Carries: (beam conditioning only)
 :z position: 27626 mm (ref 2: centre of optic; mirror-1 axis)
@@ -955,6 +956,14 @@ Optique Peter MICRX080 microscope
    and Adimec Quartz Q-12A180) have been replaced; the manual's §16
    table is still informative for object-field / oversampling
    estimates if you substitute the Oryx pixel size and sensor format.
+   cora now records the **PCO Dimax HS** under the Decommissioned
+   block of ``docs/deployments/2-bm/assets.md`` with rationale
+   "superseded by the FLIR Oryx detector chain" (per cora's #89).
+   cora's ``Camera`` Family schema is now made explicit at 2-BM
+   with ``max_framerate_hz``, ``sensor_kind``, and ``readout_mode``
+   fields so the high-framerate Dimax and the general-purpose Oryx
+   share one Family (the variant-as-settings rule, not variant-
+   as-subtype).
 :Objectives:
    Current ANL configuration, three slots:
 
@@ -1174,8 +1183,14 @@ softGlueZynq (PSO → camera trigger)
    delay, a 2:1 MUX between raw PSO and a software-defined custom
    pattern (``trigILF``), and a ``memPulseSeq`` block for arbitrary
    interlaced sequences.
-:Family: ``TriggerFPGA``
-   (matches cora's Pending entry ``softGlueZynq_FPGA``)
+:Family: ``TimingController``
+   (cora's Pending entry ``softGlueZynq_FPGA`` carries Family
+   ``TimingController`` — the second ``<Domain>Controller`` Family
+   after ``MotionController``. Affordance is ``Pulsing`` via the
+   ``Controller`` Role: the timing box is itself the actor, not a
+   driven device. Substrate "FPGA" is not a Family axis; the
+   ``TriggerFPGA`` placeholder we previously cited has been
+   superseded by ``TimingController`` per cora's #89.)
 :Hardware: APS softGlueZynq — Xilinx Zynq SoC (FPGA + ARM) on a
    MicroZed-class carrier. The EPICS IOC runs on the ARM core and
    starts automatically at boot.

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -192,6 +192,17 @@ A-shutter (front-end)
    below) further downstream. Both must be open for beam to reach
    2-BM-B.
 
+.. note::
+
+   **2-BM-A motor controller.** Every ``2bma:mNN`` motor cited in
+   the 2-BM-A blocks below (L3 Slits, Y3-30 Mirror, DMM, B-station
+   Slits, etc.) is a slot on the OMS-VME58 card in the ``ioc2bma``
+   crate — cora Asset ``OMS_VME58_2bma_drive``. None of those
+   driven stages are themselves modelled as cora Assets yet (the
+   front-end / beam-conditioning band stays in cora's Pending
+   list); the controller Asset ships in isolation as the
+   addressability handle for "controller-level" Procedures.
+
 L3 Slits
 ~~~~~~~~
 
@@ -641,9 +652,9 @@ Kinematic chain (bottom to top)::
    ``Sample_top_Roll`` and ``Sample_top_Pitch`` correspond to the
    hexapod's Roll (``2bmHXP:m5``) and Pitch (``2bmHXP:m4``) axes —
    they are part of the **Hexapod_2BM** block below, not separate
-   per-component stages above the rotary. (cora's ``LinearStage``
-   Family annotation for these two is a misnomer; they are
-   rotational hexapod axes.)
+   per-component stages above the rotary. cora classifies these
+   two as ``PseudoAxis`` Assets ("virtual DoFs over the 2bmHXP
+   hexapod-kinematics solver"), confirming the same mapping.
 
 .. note::
 
@@ -720,6 +731,8 @@ Hexapod_2BM
    integrated as a system).
 :Mounted on: Sample optical table
 :Carries: Sample_pitch_lam
+:Driven by: ``Aerotech_Hexapod_drive`` (cora ``MotionController``
+   Asset; specific product line not yet confirmed on this page)
 :Degrees of freedom: X, Y, Z, A (θ\ :sub:`x`), B (θ\ :sub:`y`), C (θ\ :sub:`z`)
 :Travel:
    X 55 mm, Y 60 mm, Z 25 mm, A 15°, B 15°, C 30° (single-axis moves
@@ -811,6 +824,8 @@ Aerotech_ABRS_rotary
    ABS250MP, not an ABRS.
 :Mounted on: Sample_pitch_lam (via a fixed -10° wedge — see above)
 :Carries: Sample_top_X, Sample_top_Z
+:Driven by: ``Aerotech_Ensemble_drive`` (cora ``MotionController``
+   Asset wrapping the Aerotech Ensemble HLE10-40-A-MXH)
 :Travel: -360 deg to +360 deg
 :Max speed: 720 deg/s
 :Encoder resolution: 0.0001 deg
@@ -850,6 +865,9 @@ Sample_top_X
    (matches ``LENS_SAMPLE_X`` in
    ``iocBoot/iocMCTOptics/mctOptics.substitutions`` — this is the
    sample-side X motor MCTOptics drives for lens/sample alignment.)
+:Driven by: ``OMS_VME58_2bmb_drive`` (cora ``MotionController``
+   Asset wrapping the OMS-VME58 card in ``ioc2bmb`` that hosts
+   the entire ``2bmb:m1``–``m91`` motor band)
 
 Sample_top_Z
 ------------
@@ -875,6 +893,8 @@ Sample_top_Z
    (matches ``LENS_SAMPLE_Z`` in
    ``iocBoot/iocMCTOptics/mctOptics.substitutions`` — this is the
    sample-side Z motor MCTOptics drives for lens/sample alignment.)
+:Driven by: ``OMS_VME58_2bmb_drive`` (cora ``MotionController``
+   Asset; same as ``Sample_top_X``)
 
 
 Detector system
@@ -1034,6 +1054,11 @@ Macro                        PV                      Purpose
 ``TOMOSCAN``                 ``2bmb:TomoScan:``      Linked TomoScan IOC
 ===========================  ======================  ================================
 
+All eight ``2bmb:m1``–``m8`` motors in this map plus ``m17``
+and ``m18`` are slots on the same OMS-VME58 card — cora Asset
+``OMS_VME58_2bmb_drive``. The hexapod motor ``2bmHXP:m3`` is one
+DoF of ``Hexapod_2BM``, driven by ``Aerotech_Hexapod_drive``.
+
 Calibrated lens positions (mm, both cameras): Pos. 0 = -60.030,
 Pos. 1 = -0.8370, Pos. 2 = 58.64. Camera positions: Pos. 0 = 20,
 Pos. 1 = 15. Per-objective and per-camera fine focus and rotation
@@ -1051,8 +1076,11 @@ offsets are held in the IOC's autosave file.
    ``Default`` button restores the per-combination calibrated
    focus / rotation values from the IOC's autosave file.
 
-Optique Peter Z stage
+Optique_Peter_focus_Z
 ---------------------
+
+(cora Asset identifier; previously called "Optique Peter Z stage"
+in this page.)
 
 :Role: Carries the entire microscope body along the beam from
    near-contact with the sample out to ~1 m for phase-contrast
@@ -1060,9 +1088,12 @@ Optique Peter Z stage
 :Family: LinearStage
 :Model: Aerotech **PRO225SL-1000** mechanical-bearing linear stage
    (SL precision class, 1000 mm travel; the longest member of the
-   PRO225SL family).
+   PRO225SL family). cora Model: ``aerotech_pro225sl_1000``.
 :Mounted on: Detector optical table
 :Carries: Optique Peter MICRX080 microscope
+:Driven by: ``Aerotech_2bmbAERO_drive`` (cora ``MotionController``
+   Asset wrapping the Aerotech drive that the ``2bmbAERO`` IOC
+   manages)
 :Travel: 1000 mm
 :Accuracy: ±18 µm (SL Standard; calibrated grade not offered above 500 mm)
 :Resolution: 0.1 µm (high-resolution feedback) / 1.0 µm

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -19,8 +19,27 @@ ops counterpart but should not duplicate it.
 For the underlying hardware (PV names, intrinsic specs, kinematic
 chain), see :doc:`manual/item_020`.
 
+
+Current procedures
+==================
+
+- :doc:`procedures/item_001` — ``Procedure template``. Canonical
+  skeleton for new procedure pages (Name / Devices / Preconditions /
+  Parameters / Steps / Postconditions / Failure modes). Copy this
+  file as ``item_NNN.rst`` to start a new procedure.
+- :doc:`procedures/item_002` —
+  ``detector_z_rail_alignment``. Walks the Optique Peter detector
+  along its 1 m PRO225SL Z rail with a small square X-ray aperture
+  defined by the B-station slits, fits the centroid drift, and uses
+  the detector optical table (``2bmb:table3.AX`` / ``.AY``) to
+  rotate the rail back parallel to the beam. Open trigger for an
+  ``OpticalTable`` Family + ``Detector_optical_table`` Asset on the
+  cora side.
+
+
 .. toctree::
    :glob:
    :maxdepth: 1
+   :hidden:
 
    procedures/item*

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -169,23 +169,33 @@ Steps
      - ``caget …`` *(persist into the Run log).*
    * - 7
      - **Iteration 0 — calibrate the table → centroid Jacobian.**
+       Measure how a small ``ΔAY`` / ``ΔAX`` step moves the
+       centroid at fixed Z (decouples the table perturbation from
+       the rail tilt the procedure is trying to remove):
 
-       (a) Move Z to ``z_near``; acquire one image; fit centroid
-       (X₀, Y₀).
+       (a) Move Z to ``z_far``; acquire baseline centroid
+       (``X_f0``, ``Y_f0``) at AY = AY_baseline.
 
-       (b) Apply test step ``Δ = z_calibration_step`` to
-       ``table3.AY``; move Z to ``z_far``; acquire image; fit
-       centroid (X₁, Y₁).
+       (b) Apply ``ΔAY = z_calibration_step`` to ``table3.AY``;
+       at the same ``z_far``, acquire centroid (``X_f1``,
+       ``Y_f1``). Compute the Jacobian column for AY:
+       ``J_AY_X = (X_f1 − X_f0) / ΔAY`` and
+       ``J_AY_Y = (Y_f1 − Y_f0) / ΔAY``. Restore AY.
 
-       (c) Compute ``J_AY_X = (X₁ − X₀) / Δ`` (object-side µm of
-       centroid shift per µrad of AY). Repeat with AX → ``J_AX_Y``.
+       (c) Apply ``ΔAX = z_calibration_step`` to ``table3.AX``;
+       at ``z_far``, acquire centroid (``X_f2``, ``Y_f2``).
+       Compute ``J_AX_X = (X_f2 − X_f0) / ΔAX`` and
+       ``J_AX_Y = (Y_f2 − Y_f0) / ΔAX``. Restore AX.
 
-       (d) Restore table to baseline.
-     - ``caput 2bmbAERO:m1 …``; ``caput 2bmSP1:cam1:Acquire 1``;
-       ``caget 2bmSP1:image1:ArrayData …`` (or use an external
-       client to grab the frame and compute the centroid). For
-       the table:
-       ``caput 2bmb:table3.AY <baseline_AY + Δ>``.
+       (d) Sanity-check: ``|J_AY_X|`` and ``|J_AX_Y|`` should be
+       well above noise (else the test step was too small, slits
+       were closed, or the table didn't actually move). Abort
+       cleanly if either is below a configurable floor.
+     - ``caput 2bmbAERO:m1 …``;
+       ``caput 2bmSP1:cam1:Acquire 1``;
+       ``caget 2bmSP1:image1:ArrayData …``; for the table:
+       ``caput 2bmb:table3.AY <baseline_AY + ΔAY>`` etc., each
+       followed by ``cawait …DMOV == 1``.
    * - 8
      - **Iterative correction.** For ``i = 1 … max_iterations``:
 

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -1,0 +1,321 @@
+==========================================
+Detector Z-rail alignment to the beam
+==========================================
+
+Walk the Optique Peter detector along its 1 m Z stage with a small
+square X-ray aperture defined by the upstream slits, watch the
+centroid drift, and use the **detector optical table** beneath the
+Z stage to rotate the rail back parallel to the beam.
+
+This procedure removes the **linear** misalignment between the rail
+axis and the beam axis. The **non-linear** residual after this
+procedure is the intrinsic straightness of the PRO225SL-1000 rail
+(~9.5 µm horizontal and vertical straightness per the datasheet) —
+that floor is not correctable from the table.
+
+For the hardware reference (table virtual axes, motor map, PV
+prefixes), see :doc:`../manual/item_020`.
+
+
+Name
+----
+
+``detector_z_rail_alignment``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **Optique_Peter_focus_Z** —
+  ``2bmbAERO:m1`` (Aerotech PRO225SL-1000, 1 m travel).
+- :doc:`../manual/item_020`: **Detector optical table** —
+  virtual record ``2bmb:table3``; corrective DoFs ``.AX`` (pitch
+  about lab-X, corrects vertical slope) and ``.AY`` (yaw about
+  lab-Y, corrects horizontal slope); centring DoFs ``.X`` and
+  ``.Y``.
+
+  Not yet a cora Asset — registering one (Family ``OpticalTable``,
+  bound to ``OMS_VME58_2bmb_drive``) is the open trigger this
+  procedure creates.
+
+- :doc:`../manual/item_020`: **MCTOptics** Component —
+  ``2bm:MCTOptics:LensSelect`` for objective selection.
+- :doc:`../manual/item_020`: **Oryx 5MP camera** (camera 0) —
+  areaDetector prefix ``2bmSP1:``.
+- :doc:`../manual/item_020`: **Scintillator_LuAG** — passive
+  (no command surface).
+- :doc:`../manual/item_020`: **B-station slits** —
+  ``2bma:m9/m10`` (Y pair) and ``2bma:m11/m12`` (X pair) for
+  shaping the small square aperture immediately upstream of the
+  sample / detector.
+- :doc:`../manual/item_020`: **A-shutter (front-end)** —
+  ``S02BM-PSS:FES:OpenEPICSC`` / ``CloseEPICSC``.
+
+
+Preconditions
+-------------
+
+- Beamline is running in white-beam mode (DMM out, filters set
+  for indirect-detection imaging).
+- Optique Peter ``MCTOptics`` IOC is up
+  (``2bm:MCTOptics:ServerRunning = Running``).
+- ``Optique_Peter_focus_Z`` is homed and at a known position.
+- ``2bmb:table3`` motors are at their commissioned baseline
+  positions (record before starting so the procedure is
+  reversible).
+- Nobody is in 19-BM-B; PSS interlocks satisfied.
+- Sample stage is in a safe out-of-beam position (the procedure
+  does not touch it, but a misaligned rail can put the beam in
+  unexpected places).
+
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 12 52
+
+   * - Name
+     - Type
+     - Unit
+     - Description
+   * - ``z_near``
+     - number
+     - mm
+     - Upstream Z anchor for the two-point measurement. Default:
+       50 mm above the rail's lower travel limit.
+   * - ``z_far``
+     - number
+     - mm
+     - Downstream Z anchor. Default: 350 mm above ``z_near``
+       (300 mm lever arm).
+   * - ``z_calibration_step``
+     - number > 0
+     - µrad
+     - Test step in ``table3.AX`` / ``.AY`` used to discover the
+       sign and magnitude of the table → centroid Jacobian on
+       iteration 0. Default: 50 µrad.
+   * - ``lens_slot``
+     - integer 0–2
+     - —
+     - Objective slot to use. Default: 0 (1.1× — gives the
+       widest field of view).
+   * - ``camera_slot``
+     - integer 0–1
+     - —
+     - Camera to use. Default: 0 (Oryx 5MP at ``2bmSP1:``).
+   * - ``exposure_time``
+     - number > 0
+     - s
+     - Per-frame exposure. Default: TBD, set by operator from
+       a quick free-run check.
+   * - ``slit_size_h``
+     - number > 0
+     - mm
+     - B-station horizontal aperture (sets the square width).
+       Default: 1.0 mm.
+   * - ``slit_size_v``
+     - number > 0
+     - mm
+     - B-station vertical aperture. Default: 1.0 mm.
+   * - ``convergence_threshold``
+     - number > 0
+     - µrad
+     - Residual linear slope at or below which the procedure
+       stops iterating. Default: 5 µrad (≈ ±1.5 µm shift over a
+       300 mm lever arm at 1.1× — below 1 object-side pixel).
+   * - ``max_iterations``
+     - integer ≥ 1
+     - —
+     - Safety cap. Default: 5.
+
+
+Steps
+-----
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 32 63
+
+   * - #
+     - Action
+     - PV / call
+   * - 1
+     - Insert the 1.1× lens.
+     - ``caput 2bm:MCTOptics:LensSelect`` *(value =* ``lens_slot`` *,
+       default 0; wait for* ``LensSelected`` *to match)*
+   * - 2
+     - Select camera 0.
+     - ``caput 2bm:MCTOptics:CameraSelect`` *(0)*
+   * - 3
+     - Set exposure time.
+     - ``caput 2bmSP1:cam1:AcquireTime`` *(* ``exposure_time`` *)*
+   * - 4
+     - Set the B-station slits to the requested square.
+     - ``caput 2bma:Slit2H:size`` *(* ``slit_size_h`` *)*,
+       ``caput 2bma:Slit2V:size`` *(* ``slit_size_v`` *)* — *(verify
+       the exact size / centre composite PV names against
+       ``2slit.adl``; the underlying blades are*
+       ``2bma:m11/m12`` *(X) and* ``2bma:m9/m10`` *(Y))*
+   * - 5
+     - Open the front-end shutter.
+     - ``caput S02BM-PSS:FES:OpenEPICSC 1``; wait for
+       ``S02BM-PSS:FES:Position`` to read OPEN.
+   * - 6
+     - Record baseline. Save current table positions
+       ``2bmb:table3.AX``, ``.AY``, ``.X``, ``.Y`` so the procedure
+       is reversible on abort.
+     - ``caget …`` *(persist into the Run log).*
+   * - 7
+     - **Iteration 0 — calibrate the table → centroid Jacobian.**
+
+       (a) Move Z to ``z_near``; acquire one image; fit centroid
+       (X₀, Y₀).
+
+       (b) Apply test step ``Δ = z_calibration_step`` to
+       ``table3.AY``; move Z to ``z_far``; acquire image; fit
+       centroid (X₁, Y₁).
+
+       (c) Compute ``J_AY_X = (X₁ − X₀) / Δ`` (object-side µm of
+       centroid shift per µrad of AY). Repeat with AX → ``J_AX_Y``.
+
+       (d) Restore table to baseline.
+     - ``caput 2bmbAERO:m1 …``; ``caput 2bmSP1:cam1:Acquire 1``;
+       ``caget 2bmSP1:image1:ArrayData …`` (or use an external
+       client to grab the frame and compute the centroid). For
+       the table:
+       ``caput 2bmb:table3.AY <baseline_AY + Δ>``.
+   * - 8
+     - **Iterative correction.** For ``i = 1 … max_iterations``:
+
+       (a) Acquire frames at ``z_near`` and ``z_far``; fit centroids;
+       compute slopes
+       ``slope_X = (X_far − X_near) / (z_far − z_near)`` and
+       ``slope_Y = (Y_far − Y_near) / (z_far − z_near)`` in
+       object-side µm per mm of Z.
+
+       (b) Convert to angular misalignment (µrad).
+
+       (c) If ``|slope_X|`` and ``|slope_Y|`` are both below
+       ``convergence_threshold``, **break**.
+
+       (d) Apply correction:
+       ``AY_new = AY_current − slope_X / J_AY_X`` (signs from
+       calibration); ``AX_new = AX_current − slope_Y / J_AX_Y``.
+       Wait for both axes to reach the setpoint.
+     - ``caput 2bmb:table3.AY <new>``,
+       ``caput 2bmb:table3.AX <new>``;
+       ``cawait 2bmb:table3.AY.DMOV == 1`` etc.
+   * - 9
+     - **Verification scan (optional).** Scan
+       ``2bmbAERO:m1`` continuously across the full 1 m travel,
+       log centroid vs Z. Report (a) the linear residual fit
+       (should be ≤ ``convergence_threshold``) and (b) the
+       wobble envelope of the non-linear residual.
+     - Standard sscan record or an external scan client.
+   * - 10
+     - Close the front-end shutter.
+     - ``caput S02BM-PSS:FES:CloseEPICSC 1``
+
+
+Postconditions
+--------------
+
+- ``|slope_X|`` and ``|slope_Y|`` over the ``[z_near, z_far]``
+  lever arm are both below ``convergence_threshold``.
+- ``2bmb:table3.AX``, ``.AY``, ``.X``, ``.Y`` are at the
+  converged values; their new positions are logged.
+- ``Optique_Peter_focus_Z`` is left at ``z_near`` (or at the
+  position the operator wants to start a Run from).
+- The front-end shutter is closed.
+- The centroid-vs-Z log is persisted with the Run record.
+
+
+Failure modes
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Symptom
+     - Recovery
+   * - No signal at ``z_near`` after step 5 (image is all noise).
+     - Slits closed too tight, beam off-centre, or shutter chain
+       interlocked. Verify the BLEPS status (no Fault latched);
+       open the B-station slits to a known-good 5 × 5 mm; re-
+       check; abort and call beamline staff if still dark.
+   * - Square aperture exits the camera field of view as Z is
+       moved.
+     - The initial misalignment is too large for the 1.1× FOV.
+       Reduce ``z_far`` to a shorter lever arm; do a coarser
+       table correction by eye on the live view first; then
+       restart at the requested lever arm.
+   * - Convergence not reached after ``max_iterations``.
+     - Restore the table to the baseline values recorded in step
+       6; close the shutter; log the residual slopes and the
+       last centroid positions; escalate. Almost always means
+       the Jacobian sign discovery in iteration 0 was wrong
+       (slits drifted, centroid algorithm misfit) — re-run with
+       a brighter aperture and a Gaussian fit instead of COM.
+   * - ``2bmbAERO:m1`` trips an Aerotech fault during a Z move.
+     - Stop the procedure; manually clear the drive fault per
+       the Aerotech operator screen; verify the table positions
+       have not slipped; resume.
+
+
+Operator walkthrough
+--------------------
+
+This procedure is intentionally written so an operator can step
+through it manually on the MEDM screens:
+
+- **Lens / camera select** — ``mctOptics`` operator screen
+  (LensSelect / CameraSelect).
+- **Slits** — ``2slit.adl`` for the B-station horizontal +
+  vertical screens (see :doc:`../manual/item_020` for the
+  label-flip caveat on the horizontal blades).
+- **Z stage** — ``2bmbAERO`` motor screen for ``m1``.
+- **Optical table corrections** — ``table_full.adl`` for
+  ``2bmb:table3`` (use the Translate column for ``X / Y / Z``
+  and the Rotate column for ``AX / AY / AZ``; the composites
+  back-drive the underlying corner motors).
+- **Centroid** — the simplest live read is the camera live view
+  plus a thresholded ROI in the areaDetector ROI plugin; the
+  procedure's slope computation can be done by hand on a
+  notepad for the first few iterations.
+
+For a fully automated implementation, see the corresponding cora
+Capability / Method / Recipe (when registered) at
+``apps/api/src/cora/recipe/``.
+
+
+Notes
+-----
+
+- The PRO225SL-1000 datasheet quotes ±9.5 µm horizontal /
+  vertical straightness over the full 1 m travel — that is the
+  floor of the non-linear residual once this procedure has
+  removed the linear tilt. Operators should not chase residuals
+  below that envelope.
+- The detector optical table is described in detail in
+  :doc:`../manual/item_020` (Detector optical table block; SRI
+  geometry, M0X=``m13``, M0Y=``m14``, M1Y=``m12``, M2X=``m10``,
+  M2Y=``m9``, M2Z=``m11``; virtual record at ``2bmb:table3``).
+- **Sign convention** for ``table3.AX`` / ``.AY`` vs centroid
+  drift is discovered at iteration 0 of step 7 — do not hard-
+  code a sign in the implementation, derive it from the
+  calibration Jacobian.
+- This procedure is **not** the same as cora's stubbed
+  ``resolution_alignment`` (which targets the same
+  ``Optique_Peter_focus_Z`` Asset but optimises **lens focus**
+  on a fixed sample, not the rail-to-beam angular alignment).
+  Both procedures share Assets but operate on different
+  physical surfaces.
+- Open trigger this procedure creates: register a
+  ``Detector_optical_table`` Asset (Family ``OpticalTable``,
+  bound to ``OMS_VME58_2bmb_drive``) in
+  ``cora/docs/deployments/2-bm/assets.md``, then add a
+  ``detector_z_rail_alignment`` entry to that deployment's
+  ``procedures.md`` referencing this page.


### PR DESCRIPTION
## Summary

Five commits — two sync rounds against the recent cora 2-BM restructure
(MotionController / PseudoAxis / TimingController family additions),
and a new procedure page documenting the detector Z-rail alignment
that uses the detector optical table beneath the 1 m PRO225SL Z stage
to remove rail-vs-beam angular misalignment.

## Commits

### 1. `docs(item_020): sync with cora 2-BM restructure (MotionController Assets, PseudoAxis, Optique_Peter_focus_Z)` — `28b275a`

cora landed a major restructure of the 2-BM Asset inventory
(`#67`, `#79`, `#80`, `#82`):

- Controllers are now first-class `MotionController` Assets
  (`Aerotech_Ensemble_drive`, `Aerotech_Hexapod_drive`,
  `Aerotech_2bmbAERO_drive`, `OMS_VME58_2bmb_drive`,
  `OMS_VME58_2bma_drive`).
- `Sample_top_Roll` / `Sample_top_Pitch` reclassified from
  `LinearStage` (which the previous note flagged as a misnomer) to
  `PseudoAxis` over the 2bmHXP hexapod-kinematics solver.
- `MCTOptics` is now an Assembly + Fixture pair.
- The Optique Peter Z stage's canonical identifier is
  `Optique_Peter_focus_Z` (no longer described as "shared focus").

Three low-friction edits keep item_020 aligned without changing any
hardware facts:

- Rename the "Optique Peter Z stage" subsection to
  `Optique_Peter_focus_Z` and cite cora's Model
  `aerotech_pro225sl_1000` alongside the manufacturer part number.
- Rewrite the Sample_top_Roll/Pitch note: cora classifies these as
  `PseudoAxis` Assets confirming the hexapod-axes mapping the note
  already showed.
- Add `:Driven by:` lines on every drive-citing block
  (`Aerotech_ABRS_rotary`, `Hexapod_2BM`, `Optique_Peter_focus_Z`,
  `Sample_top_X`, `Sample_top_Z`) plus a paragraph at the head of
  the MCTOptics motor map noting that `m1`–`m8`, `m17`, `m18` all
  live on `OMS_VME58_2bmb_drive`. One-paragraph note above the L3
  Slits block pointing every `2bma:mNN` motor at
  `OMS_VME58_2bma_drive`.

### 2. `docs(item_020): sync with cora #89 — TimingController, Y3-30_mirror, PCO Dimax Decommissioned` — `8efb209`

cora's `#89` (`define TimingController family + fix 2-BM doc/
descriptor drift`) renamed two Pending Assets and added a
Decommissioned section. Three small in-place updates:

- **softGlueZynq** block: Family `TriggerFPGA` → `TimingController`.
  The `TriggerFPGA` placeholder is gone; cora now defines
  `TimingController` as the second `<Domain>Controller` Family after
  `MotionController`, with `Pulsing` affordance via the `Controller`
  Role.
- **Y3-30 Mirror** block: cora Pending Asset is now `Y3-30_mirror`
  (was `Mirror_2BM`). Same Family.
- **MCTOptics Cameras** block: note that PCO Dimax HS moved from
  cora's Pending to a new Decommissioned section ("superseded by
  FLIR Oryx detector chain"), and that cora's `Camera` Family
  schema is now explicit (`max_framerate_hz`, `sensor_kind`,
  `readout_mode`) so the high-framerate Dimax and general-purpose
  Oryx share one Family (variant-as-settings).

### 3. `docs(procedures): add detector Z-rail alignment procedure (item_002)` — `e785442`

Drafts `detector_z_rail_alignment` as `procedures/item_002.rst`,
modelled on the cora-consumable template at `item_001.rst`.

Purpose: walk the Optique Peter detector along its 1 m PRO225SL Z
stage with a small square X-ray aperture from the B-station slits,
watch the centroid drift, and use the detector optical table's AX
(pitch) and AY (yaw) DoFs to rotate the rail back parallel to the
beam axis. Removes the LINEAR misalignment; leaves the non-linear
residual that is the intrinsic straightness floor of the PRO225SL
(~9.5 µm per the datasheet).

Structured block populated end-to-end (`Name` / `Devices` /
`Preconditions` / `Parameters` / `Steps` / `Postconditions` /
`Failure modes` / `Operator walkthrough` / `Notes`).

Two cora gaps the procedure makes explicit and tracks as open
triggers:

1. cora has no `OpticalTable` Family; this is the procedure that
   demands one (`caput 2bmb:table3.AX / .AY` in steps 7 and 8).
2. cora has no `Detector_optical_table` Asset; registering one
   (Family `OpticalTable`, bound to `OMS_VME58_2bmb_drive`) is the
   straightforward follow-up.

### 4. `docs: cross-link the detector Z-rail alignment procedure from item_020 + procedures index` — `c49c5dd`

- `manual/item_020.rst` (Detector optical table block): trailing
  note pointing at `procedures/item_002`, naming it as the open
  cora trigger for the missing `OpticalTable` Family +
  `Detector_optical_table` Asset.
- `procedures.rst`: new **Current procedures** bullet list above
  the toctree with one-line summaries; auto-toctree is now
  `:hidden:` to avoid rendering a duplicate list while still
  giving Sphinx the parent–child hierarchy needed for sidebar /
  prev-next nav.

### 5. `docs(procedures): correct step 7 calibration in detector Z-rail alignment` — `1ba2075`

The previous wording measured the Jacobian as
`(X_at_z_far_with_ΔAY − X_at_z_near_at_baseline) / Δ`, which mixes
the AY perturbation effect with the existing rail tilt α over the
lever arm Δz: `(X_far_pert − X_near_base) = (α + Δ_AY)·Δz`, so the
computed J carries an α-contamination term. Negligible when α is
small; can flip the sign of J when the initial misalignment is
larger than the test step — exactly the case the calibration exists
to handle.

Fix: measure the centroid **twice at z_far** — once at baseline AY,
once after applying ΔAY — same Z, so the difference reflects only
the AY perturbation. Repeat for AX. Explicit sanity-floor check that
aborts cleanly if `|J_AY_X|` or `|J_AX_Y|` falls below threshold
(test step too small, slits closed, table not moving).

Spec and implementation now match (`calibrate_jacobian()` in
`procedures/detector_z_rail_alignment.py` on
`decarlof/2bm-procedures`).

## Why this matters for cora

- Two rounds of cora-sync edits keep `item_020.rst` aligned with
  the cora 2-BM Asset inventory (controller-as-Asset model,
  PseudoAxis reclassification, TimingController formalisation,
  PCO Dimax decommissioning).
- The new procedure page formalises the first operationally-
  executable procedure at 2-BM; it doubles as the open trigger for
  cora to add an `OpticalTable` Family + `Detector_optical_table`
  Asset, both of which item_020 has already documented in hardware
  terms but cora hasn't yet picked up.

## Test plan

- [ ] `make html` in `docs/` runs cleanly. The step-7 list-table
      change in `procedures/item_002.rst` is a body rewrite — no new
      headings or table layouts.
- [ ] New `procedures/item_002.rst` page renders, all `:doc:`
      cross-references to `manual/item_020.rst` resolve.
- [ ] `procedures.rst` index shows the "Current procedures" bullet
      list above the (now hidden) toctree; sidebar nav still shows
      `item_001` and `item_002` as children.
- [ ] `manual/item_020.rst` Detector optical table block ends with
      the trailing `.. note::` pointing at `procedures/item_002`.