### PR TITLE
docs: rewrite item_002 from live runs; add shutter status PVs

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -567,6 +567,20 @@ P6-50 Safety Shutter (B-shutter)
 :EPICS prefix: ``S02BM-PSS:SBS``
 :Open command: ``S02BM-PSS:SBS:OpenEPICSC``
 :Close command: ``S02BM-PSS:SBS:CloseEPICSC``
+:Status readback: ``S02BM-PSS:SBS:BeamBlockingM`` (``DBF_ENUM``,
+   read-only; description ``SBS BLEPS Status``; hosted on the PSS
+   gateway ``s2pvgate``). The status is reported via BLEPS rather
+   than the PSS directly.
+
+   - STATE 0 = ``OFF`` → beam is **not** being blocked →
+     **shutter OPEN**.
+   - STATE 1 = ``ON``  → beam **is** being blocked →
+     **shutter CLOSED**.
+
+   Same inverted semantics as the A-shutter ``BeamBlockingM`` PV
+   above: the readback reports the *blocking state*, not the
+   *shutter position*. After issuing ``OpenEPICSC`` /
+   ``CloseEPICSC`` confirm by reading ``BeamBlockingM``.
 :Notes:
    One element of the four-component P6-50 stack (white-beam stop,
    tungsten collimator, safety shutter, SS baffle) installed

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -187,6 +187,19 @@ A-shutter (front-end)
 :EPICS prefix: ``S02BM-PSS:FES``
 :Open command: ``S02BM-PSS:FES:OpenEPICSC``
 :Close command: ``S02BM-PSS:FES:CloseEPICSC``
+:Status readback: ``S02BM-PSS:FES:BeamBlockingM`` (``DBF_ENUM``,
+   read-only; hosted on the PSS gateway ``s2pvgate``).
+
+   - STATE 0 = ``OFF`` → beam is **not** being blocked →
+     **shutter OPEN**.
+   - STATE 1 = ``ON``  → beam **is** being blocked →
+     **shutter CLOSED**.
+
+   Note the inverted semantics: the PV reports the *blocking
+   state*, not the *shutter position*. After issuing
+   ``OpenEPICSC`` / ``CloseEPICSC`` confirm the state by reading
+   ``BeamBlockingM`` (``caget`` returns the string ``OFF`` /
+   ``ON`` when called with ``-S``; the integer 0 / 1 by default).
 :Notes:
    Independent of the P6-50 personnel-safety shutter (``B_shutter``,
    below) further downstream. Both must be open for beam to reach

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -201,6 +201,16 @@ Parameters
        ``|slope|`` at iteration N−1 by more than this factor.
        Default: 1.5. Catches runaway positive feedback before
        it walks the spot off the camera.
+   * - ``max_correction_per_iter_urad``
+     - > 0
+     - µrad
+     - Hard clip on the per-iteration correction magnitude for
+       each table axis. Default: 200. When the calibrated
+       sensitivity matrix M is ill-conditioned (table has weak
+       authority over one slope direction), M⁻¹ can compute very
+       large corrections; the clip keeps each iteration within
+       the linear range near the calibration point. Convergence
+       happens over more iterations rather than one big move.
    * - ``threshold_fraction``
      - 0 < x < 1
      - —

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -29,44 +29,97 @@ Devices
 - :doc:`../manual/item_020`: **Optique_Peter_focus_Z** —
   ``2bmbAERO:m1`` (Aerotech PRO225SL-1000, 1 m travel).
 - :doc:`../manual/item_020`: **Detector optical table** —
-  virtual record ``2bmb:table3``; corrective DoFs ``.AX`` (pitch
-  about lab-X, corrects vertical slope) and ``.AY`` (yaw about
-  lab-Y, corrects horizontal slope); centring DoFs ``.X`` and
-  ``.Y``.
+  synApps ``table.db`` composite ``2bmb:table3``; corrective DoFs
+  ``.AX`` (pitch about lab-X, corrects vertical slope) and ``.AY``
+  (yaw about lab-Y, corrects horizontal slope). Underlying jacks
+  (per item_020.rst) — ``2bmb:m9 / m10 / m11 / m12 / m13 / m14``;
+  motion-done detected by ANDing all six ``.DMOV`` fields.
 
-  Not yet a cora Asset — registering one (Family ``OpticalTable``,
-  bound to ``OMS_VME58_2bmb_drive``) is the open trigger this
-  procedure creates.
+  Not yet a cora Asset — registering one (Family ``OpticalTable``)
+  is the open trigger this procedure creates.
 
-- :doc:`../manual/item_020`: **MCTOptics** Component —
-  ``2bm:MCTOptics:LensSelect`` for objective selection.
-- :doc:`../manual/item_020`: **Oryx 5MP camera** (camera 0) —
-  areaDetector prefix ``2bmSP1:``.
+- :doc:`../manual/item_020`: **MCTOptics** — read only.
+  ``2bm:MCTOptics:CameraSelected`` and ``LensSelected`` are read
+  to derive the camera areaDetector prefix and the lens
+  magnification. The procedure does **not** modify either.
+
+  =================  ================  =======================
+  CameraSelected     cam_prefix        Camera
+  =================  ================  =======================
+  ``Camera 1``       ``2bmSP1:``       FLIR Oryx 5MP
+  ``Camera 2``       ``2bmSP2:``       FLIR Oryx 31MP
+  =================  ================  =======================
+
+  =================  ================
+  LensSelected       Magnification
+  =================  ================
+  ``Lens1``          1.1×
+  ``Lens2``          5.0×
+  ``Lens3``          10.0×
+  =================  ================
+
+  Magnifications are hard-coded in
+  ``detector_z_rail_alignment.py`` (``LENS_MAGNIFICATIONS``);
+  update there if the installed objectives change.
+
 - :doc:`../manual/item_020`: **Scintillator_LuAG** — passive
   (no command surface).
 - :doc:`../manual/item_020`: **B-station slits** —
   ``2bma:m9/m10`` (Y pair) and ``2bma:m11/m12`` (X pair) for
-  shaping the small square aperture immediately upstream of the
-  sample / detector.
-- :doc:`../manual/item_020`: **A-shutter (front-end)** —
-  ``S02BM-PSS:FES:OpenEPICSC`` / ``CloseEPICSC``.
+  shaping the small square aperture. Operator-set before the run;
+  not modified by the procedure.
+- **A-shutter (front-end)** — operator opens before the run; not
+  toggled by the procedure.
 
 
 Preconditions
 -------------
 
+The operator is responsible for these before launching:
+
 - Beamline is running in white-beam mode (DMM out, filters set
   for indirect-detection imaging).
-- Optique Peter ``MCTOptics`` IOC is up
-  (``2bm:MCTOptics:ServerRunning = Running``).
-- ``Optique_Peter_focus_Z`` is homed and at a known position.
-- ``2bmb:table3`` motors are at their commissioned baseline
-  positions (record before starting so the procedure is
-  reversible).
-- Nobody is in 19-BM-B; PSS interlocks satisfied.
-- Sample stage is in a safe out-of-beam position (the procedure
-  does not touch it, but a misaligned rail can put the beam in
-  unexpected places).
+- ``MCTOptics`` IOC is reachable (``2bm:MCTOptics:CameraSelected``
+  and ``LensSelected`` respond).
+- The desired **camera** is selected on the MCTOptics screen
+  (Camera 1 = Oryx 5MP, Camera 2 = Oryx 31MP).
+- The desired **lens** is selected on the MCTOptics screen
+  (Lens1 / Lens2 / Lens3).
+- ``Optique_Peter_focus_Z`` is homed and the Z stage is between
+  200 and 500 mm (the procedure's safety band; runs that ask for
+  values outside this band are rejected at ``__init__``).
+- ``2bmb:table3`` is at a known-good baseline pose.
+- B-station slits are open to a small square aperture (~1 × 1 mm
+  is the design target; the centroid algorithm needs a compact
+  bright region above ``threshold_fraction × max``).
+- Front-end shutter (FES) is **open**.
+- Nobody is in 2-BM-B; PSS interlocks satisfied.
+- Sample stage is in a safe out-of-beam position.
+
+
+Operating envelope (v0.0.1 "build trust" phase)
+-----------------------------------------------
+
+- **Z safety band** ``[200, 500]`` mm — enforced at ``__init__``;
+  the motor's own ``.HLM`` / ``.LLM`` are not modified.
+- **Per-motion confirmation gate** — before every motor motion
+  (Z, table AY, table AX) the procedure prints a plan block (PV,
+  current value, target value, delta, units) and waits for ``y``
+  or ``N`` on stdin. ``N`` aborts cleanly via ``OperatorAbort``;
+  the ``try / finally`` then runs the restore path.
+- **Snapshot + restore** — at entry the procedure captures the
+  full camera state of the active camera (``Acquire``,
+  ``AcquireTime``, ``NumImages``, ``ImageMode``, ``TriggerMode``,
+  ``TriggerSource``, ``TriggerOverlap``, ``ExposureMode``,
+  ``ArrayCallbacks``) plus the Z stage RBV. On every exit path —
+  success, abort, exception, Ctrl-C — these are restored. The
+  restore path prints its plan but is **not** gated (it must run
+  even on a panic exit); pass ``--confirm-restore`` to gate it.
+  ``table3.AY`` and ``.AX`` are deliberately NOT snapshotted —
+  their new values are the procedure's deliberate output.
+- **Operator-managed surfaces** — MCTOptics camera/lens selection,
+  B-station slit apertures, and the FES shutter are NOT touched.
+  The procedure reads what the operator has set and adapts.
 
 
 Parameters
@@ -83,52 +136,57 @@ Parameters
    * - ``z_near``
      - number
      - mm
-     - Upstream Z anchor for the two-point measurement. Default:
-       50 mm above the rail's lower travel limit.
+     - Upstream Z anchor for the two-point measurement.
+       Default: 200. Must be in ``[200, 500]``.
    * - ``z_far``
      - number
      - mm
-     - Downstream Z anchor. Default: 350 mm above ``z_near``
-       (300 mm lever arm).
+     - Downstream Z anchor. Default: 500 (300 mm lever arm).
+       Must be in ``[200, 500]`` and ``> z_near``.
    * - ``z_calibration_step``
      - number > 0
      - µrad
      - Test step in ``table3.AX`` / ``.AY`` used to discover the
        sign and magnitude of the table → centroid Jacobian on
        iteration 0. Default: 50 µrad.
-   * - ``lens_slot``
-     - integer 0–2
-     - —
-     - Objective slot to use. Default: 0 (1.1× — gives the
-       widest field of view).
-   * - ``camera_slot``
-     - integer 0–1
-     - —
-     - Camera to use. Default: 0 (Oryx 5MP at ``2bmSP1:``).
    * - ``exposure_time``
      - number > 0
      - s
-     - Per-frame exposure. Default: TBD, set by operator from
-       a quick free-run check.
-   * - ``slit_size_h``
-     - number > 0
-     - mm
-     - B-station horizontal aperture (sets the square width).
-       Default: 1.0 mm.
-   * - ``slit_size_v``
-     - number > 0
-     - mm
-     - B-station vertical aperture. Default: 1.0 mm.
+     - Per-frame exposure. Default: 0.05.
    * - ``convergence_threshold``
      - number > 0
      - µrad
      - Residual linear slope at or below which the procedure
-       stops iterating. Default: 5 µrad (≈ ±1.5 µm shift over a
-       300 mm lever arm at 1.1× — below 1 object-side pixel).
+       stops iterating. Default: 5 µrad.
    * - ``max_iterations``
      - integer ≥ 1
      - —
      - Safety cap. Default: 5.
+   * - ``threshold_fraction``
+     - 0 < x < 1
+     - —
+     - Centroid algorithm threshold as fraction of frame max.
+       Default: 0.5.
+   * - ``camera_pixel_um``
+     - number > 0
+     - µm
+     - Camera sensor pixel pitch. Default: 3.45 (Oryx 5MP and
+       31MP both have 3.45 µm pixels).
+   * - ``--yes``
+     - flag
+     - —
+     - Auto-confirm every motion prompt. Off by default
+       (interactive); use for headless / scripted runs only.
+   * - ``--confirm-restore``
+     - flag
+     - —
+     - Gate the restore path on ``y/N`` like every other motion.
+       Off by default (restore is announced but runs through).
+   * - ``--dry-run``
+     - flag
+     - —
+     - Print every planned motion and skip; never moves any
+       motor. Camera reads (e.g. PixelFormat) still happen.
 
 
 Steps
@@ -142,104 +200,112 @@ Steps
      - Action
      - PV / call
    * - 1
-     - Insert the 1.1× lens.
-     - ``caput 2bm:MCTOptics:LensSelect`` *(value =* ``lens_slot`` *,
-       default 0; wait for* ``LensSelected`` *to match)*
+     - **Detect operator-set configuration.** Read
+       ``2bm:MCTOptics:CameraSelected`` and ``LensSelected``;
+       derive ``cam_prefix`` and ``magnification`` from the
+       module's lookup tables. Abort with a clear message if
+       either PV is unreachable or returns an unknown enum value.
+     - ``caget 2bm:MCTOptics:CameraSelected``,
+       ``caget 2bm:MCTOptics:LensSelected``.
    * - 2
-     - Select camera 0.
-     - ``caput 2bm:MCTOptics:CameraSelect`` *(0)*
+     - **Snapshot pre-procedure state.** Capture the active
+       camera's full state and the Z stage RBV. Stored in a
+       ``_Snapshot`` dataclass; restored on every exit path.
+     - ``caget <cam_prefix>cam1:Acquire``,
+       ``...:AcquireTime``, ``...:NumImages``, ``...:ImageMode``,
+       ``...:TriggerMode``, ``...:TriggerSource``,
+       ``...:TriggerOverlap``, ``...:ExposureMode``,
+       ``...:ArrayCallbacks``; ``caget 2bmbAERO:m1.RBV``.
    * - 3
-     - Set exposure time.
-     - ``caput 2bmSP1:cam1:AcquireTime`` *(* ``exposure_time`` *)*
+     - **Record table baseline.** Read ``2bmb:table3.AY`` and
+       ``.AX`` so the iteration sees the operator's current
+       table pose as the zero-correction reference.
+     - ``caget 2bmb:table3.AY``, ``caget 2bmb:table3.AX``.
    * - 4
-     - Set the B-station slits to the requested square.
-     - ``caput 2bma:Slit2H:size`` *(* ``slit_size_h`` *)*,
-       ``caput 2bma:Slit2V:size`` *(* ``slit_size_v`` *)* — *(verify
-       the exact size / centre composite PV names against
-       ``2slit.adl``; the underlying blades are*
-       ``2bma:m11/m12`` *(X) and* ``2bma:m9/m10`` *(Y))*
-   * - 5
-     - Open the front-end shutter.
-     - ``caput S02BM-PSS:FES:OpenEPICSC 1``; wait for
-       ``S02BM-PSS:FES:Position`` to read OPEN.
-   * - 6
-     - Record baseline. Save current table positions
-       ``2bmb:table3.AX``, ``.AY``, ``.X``, ``.Y`` so the procedure
-       is reversible on abort.
-     - ``caget …`` *(persist into the Run log).*
-   * - 7
      - **Iteration 0 — calibrate the table → centroid Jacobian.**
        Measure how a small ``ΔAY`` / ``ΔAX`` step moves the
        centroid at fixed Z (decouples the table perturbation from
        the rail tilt the procedure is trying to remove):
 
-       (a) Move Z to ``z_far``; acquire baseline centroid
-       (``X_f0``, ``Y_f0``) at AY = AY_baseline.
+       (a) **[gated]** Move Z to ``z_far``; acquire baseline
+       centroid (``X_f0``, ``Y_f0``) at AY = AY_baseline.
 
-       (b) Apply ``ΔAY = z_calibration_step`` to ``table3.AY``;
-       at the same ``z_far``, acquire centroid (``X_f1``,
-       ``Y_f1``). Compute the Jacobian column for AY:
+       (b) **[gated]** Apply ``ΔAY = z_calibration_step`` to
+       ``table3.AY``; at the same ``z_far``, acquire centroid
+       (``X_f1``, ``Y_f1``). Compute the Jacobian column for AY:
        ``J_AY_X = (X_f1 − X_f0) / ΔAY`` and
-       ``J_AY_Y = (Y_f1 − Y_f0) / ΔAY``. Restore AY.
+       ``J_AY_Y = (Y_f1 − Y_f0) / ΔAY``.
+       **[gated]** Restore AY.
 
-       (c) Apply ``ΔAX = z_calibration_step`` to ``table3.AX``;
-       at ``z_far``, acquire centroid (``X_f2``, ``Y_f2``).
-       Compute ``J_AX_X = (X_f2 − X_f0) / ΔAX`` and
-       ``J_AX_Y = (Y_f2 − Y_f0) / ΔAX``. Restore AX.
+       (c) **[gated]** Apply ``ΔAX = z_calibration_step`` to
+       ``table3.AX``; at ``z_far``, acquire centroid (``X_f2``,
+       ``Y_f2``). Compute ``J_AX_X = (X_f2 − X_f0) / ΔAX`` and
+       ``J_AX_Y = (Y_f2 − Y_f0) / ΔAX``. **[gated]** Restore AX.
 
        (d) Sanity-check: ``|J_AY_X|`` and ``|J_AX_Y|`` should be
        well above noise (else the test step was too small, slits
        were closed, or the table didn't actually move). Abort
-       cleanly if either is below a configurable floor.
-     - ``caput 2bmbAERO:m1 …``;
-       ``caput 2bmSP1:cam1:Acquire 1``;
-       ``caget 2bmSP1:image1:ArrayData …``; for the table:
-       ``caput 2bmb:table3.AY <baseline_AY + ΔAY>`` etc., each
-       followed by ``cawait …DMOV == 1``.
-   * - 8
+       cleanly if either is below ``min_jacobian_um_per_urad``.
+     - ``move_motor 2bmbAERO:m1 …``;
+       ``move_table_axis 2bmb:table3.AY <baseline + Δ>``
+       *(writes the soft PV, then polls the AND of the six jack*
+       ``.DMOV`` *PVs);*
+       ``acquire_image(cam_prefix, exposure_time)``;
+       centre-of-mass over threshold.
+   * - 5
      - **Iterative correction.** For ``i = 1 … max_iterations``:
 
-       (a) Acquire frames at ``z_near`` and ``z_far``; fit centroids;
-       compute slopes
+       (a) **[gated]** Acquire frames at ``z_near`` and
+       ``z_far``; fit centroids; compute slopes
        ``slope_X = (X_far − X_near) / (z_far − z_near)`` and
        ``slope_Y = (Y_far − Y_near) / (z_far − z_near)`` in
        object-side µm per mm of Z.
 
        (b) Convert to angular misalignment (µrad).
 
-       (c) If ``|slope_X|`` and ``|slope_Y|`` are both below
+       (c) If ``|tilt_X|`` and ``|tilt_Y|`` are both below
        ``convergence_threshold``, **break**.
 
-       (d) Apply correction:
-       ``AY_new = AY_current − slope_X / J_AY_X`` (signs from
-       calibration); ``AX_new = AX_current − slope_Y / J_AX_Y``.
-       Wait for both axes to reach the setpoint.
-     - ``caput 2bmb:table3.AY <new>``,
-       ``caput 2bmb:table3.AX <new>``;
-       ``cawait 2bmb:table3.AY.DMOV == 1`` etc.
-   * - 9
-     - **Verification scan (optional).** Scan
-       ``2bmbAERO:m1`` continuously across the full 1 m travel,
-       log centroid vs Z. Report (a) the linear residual fit
-       (should be ≤ ``convergence_threshold``) and (b) the
-       wobble envelope of the non-linear residual.
-     - Standard sscan record or an external scan client.
-   * - 10
-     - Close the front-end shutter.
-     - ``caput S02BM-PSS:FES:CloseEPICSC 1``
+       (d) **[gated]** Apply correction:
+       ``AY_new = AY_current − tilt_X × deg/µrad`` (signs from
+       calibration); ``AX_new = AX_current − tilt_Y × deg/µrad``.
+       Both axes commanded in a single confirmation gate.
+     - ``move_table_axis 2bmb:table3.AY <new>``,
+       ``move_table_axis 2bmb:table3.AX <new>``.
+   * - 6
+     - **Restore.** Run by the ``try / finally`` on every exit
+       path. Announces the restore plan to stdout (PV →
+       captured pre-procedure value), then writes each in turn
+       with per-action exception handling so one failure does
+       not block the rest. ``table3.AY`` / ``.AX`` are NOT
+       restored — the new values are the procedure's output.
+     - ``_Snapshot.restore()`` →
+       ``caput <cam>cam1:Acquire 0``;
+       ``caput …:TriggerMode <captured>``;
+       ``caput …:ImageMode <captured>``; (etc.);
+       ``move_motor 2bmbAERO:m1 <captured Z>``;
+       optionally ``caput …:Acquire 1`` if was running.
 
 
 Postconditions
 --------------
 
-- ``|slope_X|`` and ``|slope_Y|`` over the ``[z_near, z_far]``
-  lever arm are both below ``convergence_threshold``.
-- ``2bmb:table3.AX``, ``.AY``, ``.X``, ``.Y`` are at the
-  converged values; their new positions are logged.
-- ``Optique_Peter_focus_Z`` is left at ``z_near`` (or at the
-  position the operator wants to start a Run from).
-- The front-end shutter is closed.
-- The centroid-vs-Z log is persisted with the Run record.
+- ``|tilt_X|`` and ``|tilt_Y|`` over the ``[z_near, z_far]``
+  lever arm are both below ``convergence_threshold`` (success),
+  or the iteration limit was hit and a warning logged.
+- ``2bmb:table3.AY`` and ``.AX`` are at the converged values;
+  their new positions are logged. (Procedure deliberately does
+  not restore these — they're the output.)
+- ``Optique_Peter_focus_Z`` is back at its pre-procedure RBV
+  (restored from snapshot).
+- All snapshotted camera state is back to its pre-procedure
+  values: if the camera was running Continuous on entry, it is
+  running Continuous on exit; ImageMode / TriggerMode /
+  TriggerSource / TriggerOverlap / ExposureMode / NumImages /
+  AcquireTime / ArrayCallbacks are all restored.
+- FES shutter state is unchanged (procedure does not toggle it).
+- The centroid-vs-Z log and iteration history are persisted via
+  the cora Procedure record (when ``--no-cora-log`` is not set).
 
 
 Failure modes
@@ -251,54 +317,85 @@ Failure modes
 
    * - Symptom
      - Recovery
-   * - No signal at ``z_near`` after step 5 (image is all noise).
-     - Slits closed too tight, beam off-centre, or shutter chain
-       interlocked. Verify the BLEPS status (no Fault latched);
-       open the B-station slits to a known-good 5 × 5 mm; re-
-       check; abort and call beamline staff if still dark.
+   * - ``OperatorAbort`` raised at a gate (operator answered
+       ``N`` to the y/N prompt).
+     - Procedure exits cleanly via ``try / finally``; restore
+       path runs and announces what it's putting back. Re-launch
+       when ready.
+   * - ``ValueError`` at ``__init__`` — ``z_near`` or ``z_far``
+       outside ``[200, 500]`` mm, or ``z_near >= z_far``.
+     - Adjust ``--z-near`` / ``--z-far`` flags and relaunch.
+       Snapshot has not been captured yet at this point; no
+       motion has happened; no restore needed.
+   * - ``RuntimeError`` reading MCTOptics — unknown camera or
+       lens enum, or PV unreachable.
+     - Verify MCTOptics IOC is up (host ``tomdet`` for 2-BM);
+       set Camera 1 / Camera 2 and Lens1 / Lens2 / Lens3 on the
+       MCTOptics screen; relaunch. If the lens is new and not
+       in ``LENS_MAGNIFICATIONS``, add an entry.
+   * - No signal at ``z_near`` (centroid fit fails — "no signal
+       above threshold").
+     - Slits closed too tight, beam off-centre, or shutter shut.
+       Verify BLEPS status (no Fault latched); open B-station
+       slits to a known-good 5 × 5 mm; re-open FES; re-check.
    * - Square aperture exits the camera field of view as Z is
        moved.
-     - The initial misalignment is too large for the 1.1× FOV.
-       Reduce ``z_far`` to a shorter lever arm; do a coarser
-       table correction by eye on the live view first; then
-       restart at the requested lever arm.
+     - The initial misalignment is too large for the current
+       FOV. Reduce ``z_far`` (lever arm) and / or switch to a
+       lower-magnification lens; do a coarse table correction
+       by eye first; then restart at the requested lever arm.
    * - Convergence not reached after ``max_iterations``.
-     - Restore the table to the baseline values recorded in step
-       6; close the shutter; log the residual slopes and the
-       last centroid positions; escalate. Almost always means
-       the Jacobian sign discovery in iteration 0 was wrong
-       (slits drifted, centroid algorithm misfit) — re-run with
-       a brighter aperture and a Gaussian fit instead of COM.
+     - The restore path returns the snapshot; the iteration
+       history is logged. Almost always means the Jacobian sign
+       discovery in iteration 0 was wrong (slits drifted,
+       centroid algorithm misfit) — re-run with a brighter
+       aperture, or a Gaussian fit instead of COM.
    * - ``2bmbAERO:m1`` trips an Aerotech fault during a Z move.
-     - Stop the procedure; manually clear the drive fault per
+     - The motion call raises ``TimeoutError``; ``try / finally``
+       runs restore (which will also fail on the Z axis but will
+       restore camera state). Manually clear the drive fault on
        the Aerotech operator screen; verify the table positions
-       have not slipped; resume.
+       have not slipped; relaunch.
+   * - Table move appears to complete but jacks did not actually
+       drive (``move_table_axis`` raises
+       ``TimeoutError: jacks did not reach DMOV=1``).
+     - The synApps ``table.db`` kinematic engine did not
+       propagate the soft-PV change to the underlying motors.
+       Verify the MEDM "Use" button isn't required (it shouldn't
+       be — the design uses direct writes); inspect the jack
+       motor records for fault state.
 
 
 Operator walkthrough
 --------------------
 
-This procedure is intentionally written so an operator can step
-through it manually on the MEDM screens:
+This procedure is intentionally written so an operator can verify
+it step-by-step on the MEDM screens:
 
 - **Lens / camera select** — ``mctOptics`` operator screen
-  (LensSelect / CameraSelect).
+  (LensSelect / CameraSelect). Set BEFORE launching the
+  procedure; the procedure only reads.
 - **Slits** — ``2slit.adl`` for the B-station horizontal +
   vertical screens (see :doc:`../manual/item_020` for the
-  label-flip caveat on the horizontal blades).
-- **Z stage** — ``2bmbAERO`` motor screen for ``m1``.
+  label-flip caveat on the horizontal blades). Set BEFORE
+  launching.
+- **Z stage** — ``2bmbAERO`` motor screen for ``m1``. Watch
+  this as each ``[gated]`` Z move executes.
 - **Optical table corrections** — ``table_full.adl`` for
   ``2bmb:table3`` (use the Translate column for ``X / Y / Z``
   and the Rotate column for ``AX / AY / AZ``; the composites
-  back-drive the underlying corner motors).
+  back-drive the underlying corner motors at
+  ``2bmb:m9–m14``). Watch the AY / AX text-entry fields update
+  as each ``[gated]`` table move executes.
 - **Centroid** — the simplest live read is the camera live view
   plus a thresholded ROI in the areaDetector ROI plugin; the
-  procedure's slope computation can be done by hand on a
-  notepad for the first few iterations.
+  procedure logs centroid-µm and tilt-µrad to stdout for each
+  iteration.
 
-For a fully automated implementation, see the corresponding cora
-Capability / Method / Recipe (when registered) at
-``apps/api/src/cora/recipe/``.
+The y/N gate at the terminal IS the operator's safety check —
+read the plan block before answering ``y``. If anything looks
+wrong (PV name, sign, magnitude), answer ``N`` and the procedure
+exits cleanly via the snapshot restore.
 
 
 Notes
@@ -314,9 +411,18 @@ Notes
   geometry, M0X=``m13``, M0Y=``m14``, M1Y=``m12``, M2X=``m10``,
   M2Y=``m9``, M2Z=``m11``; virtual record at ``2bmb:table3``).
 - **Sign convention** for ``table3.AX`` / ``.AY`` vs centroid
-  drift is discovered at iteration 0 of step 7 — do not hard-
+  drift is discovered at iteration 0 of step 4 — do not hard-
   code a sign in the implementation, derive it from the
   calibration Jacobian.
+- **Camera state hygiene** — the procedure changes
+  ``TriggerMode``, ``ImageMode``, ``NumImages``, and possibly
+  ``AcquireTime`` on the active camera during the run.
+  ``acquire_image()`` in ``procedures/_shared/epics.py``
+  forces ``TriggerMode=Off`` and ``ImageMode=Single`` before
+  every frame so a stale external-trigger configuration (e.g.
+  ``TriggerSource=Line2`` for PSO-triggered tomoscan Runs)
+  cannot make the call hang. All of these are restored from
+  snapshot at exit.
 - This procedure is **not** the same as cora's stubbed
   ``resolution_alignment`` (which targets the same
   ``Optique_Peter_focus_Z`` Asset but optimises **lens focus**
@@ -324,8 +430,7 @@ Notes
   Both procedures share Assets but operate on different
   physical surfaces.
 - Open trigger this procedure creates: register a
-  ``Detector_optical_table`` Asset (Family ``OpticalTable``,
-  bound to ``OMS_VME58_2bmb_drive``) in
+  ``Detector_optical_table`` Asset (Family ``OpticalTable``) in
   ``cora/docs/deployments/2-bm/assets.md``, then add a
   ``detector_z_rail_alignment`` entry to that deployment's
   ``procedures.md`` referencing this page.

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -108,11 +108,15 @@ Operating envelope (v0.0.1 "build trust" phase)
 
 - **Z safety band** ``[200, 500]`` mm — enforced at ``__init__``;
   the motor's own ``.HLM`` / ``.LLM`` are not modified.
-- **Per-motion confirmation gate** — before every motor motion
-  (Z, table AY, table AX) the procedure prints a plan block (PV,
-  current value, target value, delta, units) and waits for ``y``
-  or ``N`` on stdin. ``N`` aborts cleanly via ``OperatorAbort``;
-  the ``try / finally`` then runs the restore path.
+- **Per-motion confirmation gate** — before every **table** move
+  (calibration perturb / restore, iteration correction) the
+  procedure prints a plan block (PV, current value, target value,
+  delta, units) and waits for ``y`` or ``N`` on stdin. ``N``
+  aborts cleanly via ``OperatorAbort``; the ``try / finally``
+  then runs the restore path. **Z measurement moves** stay within
+  the safety band and only sample the alignment (don't change
+  it), so they are announced but NOT gated by default. Pass
+  ``--gate-z`` to gate them too.
 - **Snapshot + restore** — at entry the procedure captures the
   full camera state of the active camera (``Acquire``,
   ``AcquireTime``, ``NumImages``, ``ImageMode``, ``TriggerMode``,
@@ -163,9 +167,12 @@ Parameters
    * - ``z_calibration_step``
      - number > 0
      - µrad
-     - Test step in ``table3.AX`` / ``.AY`` used to discover the
-       sign and magnitude of the table → centroid Jacobian on
-       iteration 0. Default: 50 µrad.
+     - Test step in ``table3.AY`` and ``.AX`` used to discover the
+       2×2 slope-sensitivity matrix M. Default: 50 µrad. Must be
+       large enough that the resulting slope change is well above
+       the centroid noise floor (~20 µrad for the Oryx 31MP at
+       1.1× over a 300 mm Z lever). If calibration aborts with
+       "sensitivity matrix near-singular", bump to 100.
    * - ``exposure_time``
      - number > 0
      - s
@@ -179,6 +186,21 @@ Parameters
      - integer ≥ 1
      - —
      - Safety cap. Default: 5.
+   * - ``damping``
+     - 0 < d ≤ 1
+     - —
+     - Multiplier on the iteration's computed correction. 1.0 =
+       full correction, 0.5 (default) = half. Damping < 1 keeps
+       us in the linear range across iterations when the
+       sensitivity matrix is imperfect or table cross-coupling
+       exceeds what a 2×2 linear model captures.
+   * - ``divergence_grow_threshold``
+     - > 1
+     - ×
+     - Abort if ``|slope|`` at iteration N exceeds
+       ``|slope|`` at iteration N−1 by more than this factor.
+       Default: 1.5. Catches runaway positive feedback before
+       it walks the spot off the camera.
    * - ``threshold_fraction``
      - 0 < x < 1
      - —
@@ -194,6 +216,13 @@ Parameters
        effective pitch of the delivered image — so 2 × 2 binning
        gives an effective 6.9 µm pitch without any CLI override.
        If ``BinX != BinY`` a warning is logged and BinX is used.
+   * - ``--gate-z``
+     - flag
+     - —
+     - Also gate Z measurement moves on y/N. Default off: Z moves
+       stay within the safety band and only sample alignment, so
+       they're announced but not gated. Table moves are ALWAYS
+       gated regardless.
    * - ``--yes``
      - flag
      - —
@@ -208,7 +237,7 @@ Parameters
      - flag
      - —
      - Print every planned motion and skip; never moves any
-       motor. Camera reads (e.g. PixelFormat) still happen.
+       motor. Camera reads + centroid fits still happen.
 
 
 Steps
@@ -244,54 +273,66 @@ Steps
        table pose as the zero-correction reference.
      - ``caget 2bmb:table3.AY``, ``caget 2bmb:table3.AX``.
    * - 4
-     - **Iteration 0 — calibrate the table → centroid Jacobian.**
-       Measure how a small ``ΔAY`` / ``ΔAX`` step moves the
-       centroid at fixed Z (decouples the table perturbation from
-       the rail tilt the procedure is trying to remove):
+     - **Calibrate the slope-sensitivity matrix M.** For each
+       table axis (AY, AX): measure baseline slope, perturb axis
+       by ``z_calibration_step``, re-measure slope, restore axis.
+       Build the 2×2 matrix M:
 
-       (a) **[gated]** Move Z to ``z_far``; acquire baseline
-       centroid (``X_f0``, ``Y_f0``) at AY = AY_baseline.
+       .. code-block:: text
 
-       (b) **[gated]** Apply ``ΔAY = z_calibration_step`` to
-       ``table3.AY``; at the same ``z_far``, acquire centroid
-       (``X_f1``, ``Y_f1``). Compute the Jacobian column for AY:
-       ``J_AY_X = (X_f1 − X_f0) / ΔAY`` and
-       ``J_AY_Y = (Y_f1 − Y_f0) / ΔAY``.
-       **[gated]** Restore AY.
+          | Δslope_X |   | M_AY_X  M_AX_X | | ΔAY |
+          |          | = |                | |     |
+          | Δslope_Y |   | M_AY_Y  M_AX_Y | | ΔAX |
 
-       (c) **[gated]** Apply ``ΔAX = z_calibration_step`` to
-       ``table3.AX``; at ``z_far``, acquire centroid (``X_f2``,
-       ``Y_f2``). Compute ``J_AX_X = (X_f2 − X_f0) / ΔAX`` and
-       ``J_AX_Y = (Y_f2 − Y_f0) / ΔAX``. **[gated]** Restore AX.
+       where slope is in µm/mm and Δaxis in µrad.
 
-       (d) Sanity-check: ``|J_AY_X|`` and ``|J_AX_Y|`` should be
-       well above noise (else the test step was too small, slits
-       were closed, or the table didn't actually move). Abort
-       cleanly if either is below ``min_jacobian_um_per_urad``.
+       (a) Move Z to ``z_near`` → acquire; move Z to ``z_far`` →
+       acquire. Compute baseline slope (``slope0_X``, ``slope0_Y``).
+
+       (b) **[gated]** Perturb ``table3.AY`` by
+       ``+z_calibration_step``. Re-measure slope. Compute
+       ``M_AY_X = (slope_AY_X − slope0_X) / Δ`` and ``M_AY_Y``
+       likewise. **[gated]** Restore AY.
+
+       (c) **[gated]** Perturb ``table3.AX``, re-measure slope,
+       compute ``M_AX_X`` and ``M_AX_Y``. **[gated]** Restore AX.
+
+       (d) Sanity-check ``|det(M)|`` ≥ ``min_sensitivity_det``.
+       Below this, the procedure aborts with a clear "matrix
+       near-singular" message — bump ``z_calibration_step`` to
+       100 µrad and retry.
+
+       *This replaces the old centroid-shift-at-z-far "Jacobian"
+       formulation, which measured the wrong physical quantity:
+       uniform centroid shifts at fixed Z cancel between
+       z_near/z_far and leave slope unchanged. The slope
+       sensitivity is what actually drives convergence.*
      - ``move_motor 2bmbAERO:m1 …``;
-       ``move_table_axis 2bmb:table3.AY <baseline + Δ>``
-       *(writes the soft PV, then polls the AND of the six jack*
-       ``.DMOV`` *PVs);*
+       ``move_table_axis 2bmb:table3.AY <baseline + Δ>``;
        ``acquire_image(cam_prefix, exposure_time)``;
        centre-of-mass over threshold.
    * - 5
      - **Iterative correction.** For ``i = 1 … max_iterations``:
 
-       (a) **[gated]** Acquire frames at ``z_near`` and
-       ``z_far``; fit centroids; compute slopes
-       ``slope_X = (X_far − X_near) / (z_far − z_near)`` and
-       ``slope_Y = (Y_far − Y_near) / (z_far − z_near)`` in
-       object-side µm per mm of Z.
+       (a) Acquire frames at ``z_near`` and ``z_far``; fit
+       centroids; compute slopes ``slope_X``, ``slope_Y``.
 
-       (b) Convert to angular misalignment (µrad).
+       (b) Convert to angular misalignment ``tilt_X``,
+       ``tilt_Y`` (µrad).
 
-       (c) If ``|tilt_X|`` and ``|tilt_Y|`` are both below
+       (c) **Divergence guard**: if ``|tilt|`` (Euclidean) at
+       this iteration exceeds the previous iteration's by more
+       than ``divergence_grow_threshold``, raise ``RuntimeError``
+       → restore puts table AY/AX back to baseline. Aborts a
+       runaway before it walks the spot off the camera.
+
+       (d) If both ``|tilt_X|`` and ``|tilt_Y|`` are below
        ``convergence_threshold``, **break**.
 
-       (d) **[gated]** Apply correction:
-       ``AY_new = AY_current − tilt_X × deg/µrad`` (signs from
-       calibration); ``AX_new = AX_current − tilt_Y × deg/µrad``.
-       Both axes commanded in a single confirmation gate.
+       (e) **[gated]** Compute corrective ΔAY, ΔAX by solving
+       ``M @ (ΔAY, ΔAX) = −(slope_X, slope_Y)`` via
+       ``numpy.linalg.inv``; multiply by ``damping``. Apply
+       both axes in a single confirmation gate.
      - ``move_table_axis 2bmb:table3.AY <new>``,
        ``move_table_axis 2bmb:table3.AX <new>``.
    * - 6

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -117,12 +117,23 @@ Operating envelope (v0.0.1 "build trust" phase)
   full camera state of the active camera (``Acquire``,
   ``AcquireTime``, ``NumImages``, ``ImageMode``, ``TriggerMode``,
   ``TriggerSource``, ``TriggerOverlap``, ``ExposureMode``,
-  ``ArrayCallbacks``) plus the Z stage RBV. On every exit path —
-  success, abort, exception, Ctrl-C — these are restored. The
-  restore path prints its plan but is **not** gated (it must run
-  even on a panic exit); pass ``--confirm-restore`` to gate it.
-  ``table3.AY`` and ``.AX`` are deliberately NOT snapshotted —
-  their new values are the procedure's deliberate output.
+  ``ArrayCallbacks``), the Z stage RBV, **and** the table soft
+  axes ``2bmb:table3.AY`` / ``.AX``. On every exit path the camera
+  state and Z position are restored. The table AY/AX are restored
+  **only on non-success exits** (``OperatorAbort``, exception,
+  max-iterations reached without convergence) — on clean
+  convergence the optimised AY/AX are left in place as the
+  procedure's deliberate output. The restore path prints its plan
+  but is **not** gated (it must run even on a panic exit); pass
+  ``--confirm-restore`` to gate it.
+
+  Caveat: the table restore writes to the ``2bmb:table3.AY/.AX``
+  soft PVs; the synApps ``table.db`` kinematic does not always
+  perfectly invert a perturb-and-back cycle, so the underlying
+  jacks may end up a fraction of a microradian off their
+  pre-procedure RBVs (jack hysteresis). True per-jack restore
+  would require snapshotting and writing the six jack positions
+  directly; not implemented in v0.0.1.
 - **Operator-managed surfaces** — MCTOptics camera/lens selection,
   B-station slit apertures, and the FES shutter are NOT touched.
   The procedure reads what the operator has set and adapts.

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -176,8 +176,13 @@ Parameters
    * - ``camera_pixel_um``
      - number > 0
      - µm
-     - Camera sensor pixel pitch. Default: 3.45 (Oryx 5MP and
-       31MP both have 3.45 µm pixels).
+     - Camera **sensor** pixel pitch, pre-binning. Default: 3.45
+       (Oryx 5MP and 31MP both have 3.45 µm sensor pixels).
+       At ``detect_camera_and_lens`` time the procedure reads
+       ``cam1:BinX_RBV`` and uses ``sensor_pitch × BinX`` as the
+       effective pitch of the delivered image — so 2 × 2 binning
+       gives an effective 6.9 µm pitch without any CLI override.
+       If ``BinX != BinY`` a warning is logged and BinX is used.
    * - ``--yes``
      - flag
      - —

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -39,28 +39,34 @@ Devices
   is the open trigger this procedure creates.
 
 - :doc:`../manual/item_020`: **MCTOptics** — read only.
-  ``2bm:MCTOptics:CameraSelected`` and ``LensSelected`` are read
-  to derive the camera areaDetector prefix and the lens
-  magnification. The procedure does **not** modify either.
+  ``2bm:MCTOptics:CameraSelect`` and ``LensSelect`` (the setpoint
+  mbbo records) are read at start to derive the camera
+  areaDetector prefix and the lens magnification. The procedure
+  does **not** modify either. The lookup is keyed by the mbbo
+  **enum index** (returned by a plain ``caget`` without
+  ``as_string=True``) so it survives IOC-version differences in
+  the display strings (e.g. ``"Camera 1"`` vs
+  ``"Camera Selected 1"``).
 
-  =================  ================  =======================
-  CameraSelected     cam_prefix        Camera
-  =================  ================  =======================
-  ``Camera 1``       ``2bmSP1:``       FLIR Oryx 5MP
-  ``Camera 2``       ``2bmSP2:``       FLIR Oryx 31MP
-  =================  ================  =======================
+  ======  ==============  ================  =======================
+  Index   CameraSelect    cam_prefix        Camera
+  ======  ==============  ================  =======================
+  0       ``Camera 1``    ``2bmSP1:``       FLIR Oryx 5MP
+  1       ``Camera 2``    ``2bmSP2:``       FLIR Oryx 31MP
+  ======  ==============  ================  =======================
 
-  =================  ================
-  LensSelected       Magnification
-  =================  ================
-  ``Lens1``          1.1×
-  ``Lens2``          5.0×
-  ``Lens3``          10.0×
-  =================  ================
+  ======  ==============  ================
+  Index   LensSelect      Magnification
+  ======  ==============  ================
+  0       ``Lens1``       1.1×
+  1       ``Lens2``       5.0×
+  2       ``Lens3``       10.0×
+  ======  ==============  ================
 
   Magnifications are hard-coded in
-  ``detector_z_rail_alignment.py`` (``LENS_MAGNIFICATIONS``);
-  update there if the installed objectives change.
+  ``detector_z_rail_alignment.py``
+  (``LENS_MAGNIFICATIONS_BY_INDEX``); update there if the
+  installed objectives change.
 
 - :doc:`../manual/item_020`: **Scintillator_LuAG** — passive
   (no command surface).


### PR DESCRIPTION
## Summary

Eight follow-up commits on top of #163, in two areas:

- **`procedures/item_002.rst`** (Detector Z-rail alignment) — major rewrite
  of the executable spec based on the first live runs on 2-BM-B.
  Calibration, iteration, restore, and safety contracts all changed.
- **`manual/item_020.rst`** (Beamline components) — A-shutter and B-shutter
  blocks each gained their `BeamBlockingM` status-readback PV with the
  inverted-enum semantics documented (`OFF = OPEN`, `ON = CLOSED`).

## Background

The first version of `item_002.rst` was written from a paper design.
First-live-run sessions on 2-BM-B exposed several gaps (MCTOptics PV
naming, table.db kinematic semantics, camera binning, motor DMOV race,
procedure restore-on-abort policy, and a wrong correction formula that
caused iteration divergence). This PR aligns the spec with the
implementation that actually works, and the procedure module in
`decarlof/2bm-procedures` is updated in lock-step.

## Procedure (`docs/source/procedures/item_002.rst`)

End-to-end rewrite of the operating envelope, parameter table, steps,
and failure modes. Net `+348 lines` (the spec is now more thorough,
but the structure is the same).

### Device block

- **MCTOptics** is now documented as **read-only**. The procedure reads
  `CameraSelect` / `LensSelect` (the writable mbbo setpoints — the
  `Selected` readback PVs don't always exist or use different display
  strings on this IOC) and keys the lookup by mbbo **enum index**, not
  by display string. Camera-prefix + lens-magnification lookup tables
  added.
- **Detector optical table** documented as a synApps `table.db`
  composite. Motion-done is detected by ANDing the six underlying
  jacks' `.DMOV` PVs (the soft PV `2bmb:table3.AY` has a literal `.` in
  its name and is NOT a motor record, so it has no `.DMOV` of its own).
  Jack motor PVs cross-referenced from `item_020.rst`.
- **Camera binning** is auto-detected from `cam1:BinX_RBV` at runtime;
  the procedure multiplies the documented SENSOR pitch (3.45 µm) by the
  binning to get the effective per-frame pitch.
- **A-shutter** and **B-shutter** removed as procedure-managed
  surfaces; documented as **operator-managed** (open before launch,
  procedure does not toggle).

### New "Operating envelope (v0.0.1 build trust phase)" section

Documents the safety contract that the implementation enforces:

- **Z safety band** `[200, 500]` mm enforced at `__init__`; motor `.HLM`
  / `.LLM` are not modified.
- **Per-motion confirmation gate**: every **table** move (calibration
  perturb / restore, iteration correction) prints a plan block
  (`pv | current | target | delta | units`) and waits for `y / N`. `N`
  raises `OperatorAbort` → restore path runs in `try / finally`.
- **Z measurement moves** are announce-only by default (stay in the
  safety band, only sample alignment, don't change it). `--gate-z` flag
  restores full gating.
- **Snapshot + restore**: captures camera state (Acquire, AcquireTime,
  NumImages, ImageMode, TriggerMode, TriggerSource, TriggerOverlap,
  ExposureMode, ArrayCallbacks), Z RBV, **and** `table3.AY / .AX`. On
  every exit path the camera + Z are restored. The **table AY/AX are
  restored only on non-success exits** (abort, exception,
  max-iterations-without-convergence). On clean convergence the new
  values stay in place as the procedure's deliberate output.
- **Caveat documented**: writing back through the table soft PVs goes
  through `table.db`'s kinematic, which doesn't always perfectly invert
  a perturb-and-back cycle. True per-jack restore not implemented in
  v0.0.1.

### Parameter table

Added `damping`, `divergence_grow_threshold`,
`max_correction_per_iter_urad`, `--gate-z`. Removed `lens_slot`,
`camera_slot`, `slit_size_h`, `slit_size_v` (now operator-managed).
`z_near` / `z_far` defaults updated to 200 / 500 mm (was 50 / 350) with
the safety-band requirement documented. `camera_pixel_um` re-documented
as the **sensor** pitch, pre-binning.

### Steps

Replaced step-by-step:

1. **Detect operator-set configuration** (read MCTOptics).
2. **Snapshot pre-procedure state** (camera + Z + table baseline).
3. **Record table baseline** (`2bmb:table3.AY / .AX`).
4. **Calibrate slope-sensitivity matrix M** — for each axis (AY, AX),
   measure baseline slope, perturb axis by `z_calibration_step`,
   re-measure slope, restore axis. Builds the 2×2 matrix M of
   `Δslope_per_axis_µrad`. SVD diagnostic + singular-value check.

   *This replaces the old centroid-shift-at-z-far "Jacobian"
   formulation, which measured the wrong physical quantity: uniform
   centroid shifts at fixed Z cancel between z_near/z_far and leave
   slope unchanged. The slope sensitivity is what actually drives
   convergence.*
5. **Iterative correction** — solves `M @ (ΔAY, ΔAX) = −(slope_X, slope_Y)`
   via `numpy.linalg.inv`, multiplies by `damping`, clips to
   `±max_correction_per_iter_urad` per axis. Aborts via the
   divergence guard if `|tilt|` grows by more than
   `divergence_grow_threshold` between iterations.
6. **Restore** — runs in `try / finally`. Always restores camera + Z;
   restores table AY/AX only on non-success exits.

### Failure modes

Added: `OperatorAbort`, Z-band `ValueError`, MCTOptics enum
`RuntimeError`, table soft-move `TimeoutError`, sensitivity-matrix
near-singular `RuntimeError`. Removed outdated entries that referenced
shutter-toggling and the old Jacobian sanity floor.

### Operator walkthrough + notes

- The y/N gate at the terminal IS the operator's safety check — read
  the plan block before answering `y`.
- Sign convention is discovered empirically every run; not hard-coded.
- Cross-references to `item_020.rst` for the Detector optical table
  geometry, the soft-PV literal-dot naming, and the underlying jack map.
- camera-state-hygiene note: `acquire_image()` forces
  `TriggerMode=Off` and `ImageMode=Single` per-frame so a stale
  external-trigger config (e.g. `TriggerSource=Line2` from a tomoscan
  Run) can't hang the call.

## Manual / Beamline components (`docs/source/manual/item_020.rst`)

Two small additions, one to each shutter block (~13 lines each).

### A-shutter (front-end)

Added `:Status readback: 2bma…S02BM-PSS:FES:BeamBlockingM` block —
read-only `DBF_ENUM` hosted on the PSS gateway `s2pvgate`.
**Inverted semantics** documented: STATE 0 OFF = NOT blocking = shutter
OPEN; STATE 1 ON = blocking = shutter CLOSED. After issuing
`OpenEPICSC` / `CloseEPICSC`, read `BeamBlockingM` to confirm the
command took effect.

### B-shutter (P6-50 safety shutter)

Same pattern for `S02BM-PSS:SBS:BeamBlockingM` (description
`SBS BLEPS Status` — status comes through BLEPS rather than direct PSS;
the difference is noted). Cross-references the A-shutter explanation
for the inverted enum semantics rather than repeating it in full.

## Companion repo

The executable implementation of `detector_z_rail_alignment` lives in
`decarlof/2bm-procedures` (separate repo). Every spec change in this PR
has a matching implementation commit there. Latest tag of the
implementation is exercised live on 2-BM-B; sensitivity-matrix
calibration converges; iteration produces measurable alignment
improvement (iter 1 reduced `|tilt|` from 443 µrad → 377 µrad on the
first live run).

## Test plan

- [ ] Sphinx build succeeds with no new warnings (`make html` from
      `docs/`).
- [ ] Cross-references from `item_020.rst` → `item_002.rst` resolve.
- [ ] Cross-references from `item_002.rst` → `item_020.rst` (Detector
      optical table block, jack motor map, shutter sections) resolve.
- [ ] All eight commits in this PR have matching implementation
      commits in `decarlof/2bm-procedures`.

## Commits (newest first)

| SHA | Subject |
|-----|---------|
| `269cb9c` | docs(item_020): add SBS BeamBlockingM status PV (B-shutter) |
| `00d3354` | docs(item_020): add FES BeamBlockingM status PV with semantics |
| `44cbd42` | docs(procedures): document max_correction_per_iter_urad |
| `73a84ec` | docs(procedures): sensitivity matrix, damping, divergence guard |
| `4a336a8` | docs(procedures): document table AY/AX restore-on-abort policy |
| `8cfe977` | docs(procedures): document binning-aware pixel pitch |
| `ffa5250` | docs(procedures): align MCTOptics block with index-based detect |
| `1aeca43` | docs(procedures): rewrite item_002 for snapshot/restore + gated motion |
