### PR TITLE
docs: precondition graph + ACIS/PSS/Flag PVs + 8 procedure stubs

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -216,6 +216,62 @@ A-shutter (front-end)
    list); the controller Asset ships in isolation as the
    addressability handle for "controller-level" Procedures.
 
+Flag (diagnostic phosphor)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Role: Diagnostic phosphor screen on a vertical stage. A visible-
+   light camera looks at it so operators can see the X-ray beam
+   position and gauge intensity. In pink-beam (white-beam) mode
+   the flag is parked at its lower limit (``Y = 0 mm`` user,
+   ``5 mm`` dial) -- out of the beam. In mono mode the flag is
+   raised to block the M1-scattered halo while letting the
+   monochromatic beam pass; the exact Y is energy-dependent.
+:Family: Diagnostic (no cora Family declared yet; this is the
+   first instance of a "viewable beam diagnostic" on the 2-BM
+   inventory).
+:Mounted on: Own stand in 2-BM-A (floor-referenced).
+:Carries: phosphor-painted flag + visible camera (not modelled
+   here; the camera is its own Asset).
+:z position: ~20.6 m from source (upstream of the L3 Slits).
+   Not separately listed in the APS reference table.
+:EPICS: ``2bma:m44`` -- single vertical (Y) motor.
+:User/dial offset: user = dial - 5 mm. Limits (user, from
+   ``meters_all.adl``): -4.5 to +35.0 mm (dial 0.5 to 40.0 mm).
+
+The energy-dependent flag positions used by mono-beam scans are
+defined in the ``energy`` package's lookup table
+(``src/energy/data/energy2bm.json``, key
+``energy_move_flag``):
+
+==============  ===================  ==========================
+DMM energy keV  Flag Y (mm, user)    Comment
+==============  ===================  ==========================
+13.374          23.0                 highest (low energy)
+13.574          22.0
+18.000          17.0
+20.000          15.0
+25.000          12.0
+25.584          12.0
+30.000          0.0                  flag down (out of beam)
+40.000          0.0
+50.000          0.0
+60.000          0.0                  highest energy
+==============  ===================  ==========================
+
+Pink-beam mode: flag at ``Y = 0 mm`` (user) -- same as the
+"flag down" position used by mono at 30 keV and above.
+
+.. note::
+
+   **Procedures that command this component.**
+   :doc:`../procedures/item_006` (``set_flag_in``) is the stub
+   that satisfies the ``flag_in_beam`` precondition of
+   :doc:`../procedures/item_002` (``detector_z_rail_alignment``).
+   The energy-dependent target Y is read from the
+   ``energy_move_flag`` field of ``energy2bm.json``; operating in
+   pink mode means writing ``0 mm`` user to ``2bma:m44``.
+
+
 L3 Slits
 ~~~~~~~~
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -601,12 +601,12 @@ PSS is willing to admit beam) and ``OFF`` when the search is broken
 :Hosted on: ``s2pvgate.xray.aps.anl.gov:5064`` (PSS gateway; same
    host as the shutter ``BeamBlockingM`` PVs).
 
-==================  =============================  ==========================
-PV                  Description (``DESC``)         Meaning
-==================  =============================  ==========================
-``S02BM-PSS:StaA:SecureM``   ``Sta-A Secure``      2-BM-A hutch
-``S02BM-PSS:StaB:SecureM``   ``Sta-B Secure``      2-BM-B hutch
-==================  =============================  ==========================
+==========================  ===================  ==============
+PV                          Description (DESC)   Meaning
+==========================  ===================  ==============
+``S02BM-PSS:StaA:SecureM``  ``Sta-A Secure``     2-BM-A hutch
+``S02BM-PSS:StaB:SecureM``  ``Sta-B Secure``     2-BM-B hutch
+==========================  ===================  ==============
 
 Both PVs share the same enum:
 
@@ -620,6 +620,41 @@ These are the predicates the :doc:`../procedures/item_003`
 ``beamline_enabled`` postcondition. Both must read ``ON`` before
 the FES open command (``S02BM-PSS:FES:OpenEPICSC``) will be
 honoured.
+
+
+ACIS upstream permit
+~~~~~~~~~~~~~~~~~~~~
+
+The APS Access Control and Interlock System exposes a single
+"upstream permit" PV that aggregates storage-ring health,
+injection state, APS-wide permits, the per-beamline PSS state,
+and the BLEPS fault chain into one boolean. If it reads ``ON``,
+all of the upstream conditions required to admit beam to 2-BM
+are met -- the FES open command will be honoured.
+
+:Family: ACIS upstream permit (read-only; analogous to the PSS
+   ``SecureM`` PVs above but at a higher level of aggregation).
+:Hosted on: ``s2pvgate.xray.aps.anl.gov:5064``.
+
+==========================  =============================  ===================
+PV                          Description (``DESC``)         Meaning
+==========================  =============================  ===================
+``SR-ACIS:2BM:FesPermitM``  ``2BM PSS FES Permit``         FES open permitted
+==========================  =============================  ===================
+
+Enum:
+
+- STATE 0 = ``OFF`` → ACIS does **not** permit the FES to open
+  (some upstream condition failed -- could be storage ring down,
+  BLEPS fault latched, PSS not searched, etc.).
+- STATE 1 = ``ON``  → ACIS permits the FES to open. The
+  individual upstream conditions are all green.
+
+This is the single PV the :doc:`../procedures/item_003`
+(``enable_beamline``) stub procedure uses to test the composite
+"upstream OK" condition. It replaces the earlier
+"BLEPS-clear AND machine-state-OK" pair of TBDs because ACIS
+already composes both.
 
 
 B-station Slits

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -240,8 +240,9 @@ Flag (diagnostic phosphor)
 
 The energy-dependent flag positions used by mono-beam scans are
 defined in the ``energy`` package's lookup table
-(``src/energy/data/energy2bm.json``, key
-``energy_move_flag``):
+(`energy2bm.json
+<https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__,
+key ``energy_move_flag``):
 
 ==============  ===================  ==========================
 DMM energy keV  Flag Y (mm, user)    Comment
@@ -268,7 +269,9 @@ Pink-beam mode: flag at ``Y = 0 mm`` (user) -- same as the
    that satisfies the ``flag_in_beam`` precondition of
    :doc:`../procedures/item_002` (``detector_z_rail_alignment``).
    The energy-dependent target Y is read from the
-   ``energy_move_flag`` field of ``energy2bm.json``; operating in
+   ``energy_move_flag`` field of `energy2bm.json
+   <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__;
+   operating in
    pink mode means writing ``0 mm`` user to ``2bma:m44``.
 
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -587,6 +587,41 @@ P6-50 Safety Shutter (B-shutter)
    together at z ≈ 330 m. The other three are passive. Both this
    and the upstream A-shutter must be open for beam to reach 2-BM-B.
 
+PSS hutch search status
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The Personnel Safety System publishes a per-hutch "secure" enum
+that reads ``ON`` when the hutch is searched and locked (and the
+PSS is willing to admit beam) and ``OFF`` when the search is broken
+(door open, search active, manual override, etc.).
+
+:Family: PSS interlock readback (read-only; not a Family in the
+   cora 2-BM inventory — these are operational status PVs, not
+   commandable Assets).
+:Hosted on: ``s2pvgate.xray.aps.anl.gov:5064`` (PSS gateway; same
+   host as the shutter ``BeamBlockingM`` PVs).
+
+==================  =============================  ==========================
+PV                  Description (``DESC``)         Meaning
+==================  =============================  ==========================
+``S02BM-PSS:StaA:SecureM``   ``Sta-A Secure``      2-BM-A hutch
+``S02BM-PSS:StaB:SecureM``   ``Sta-B Secure``      2-BM-B hutch
+==================  =============================  ==========================
+
+Both PVs share the same enum:
+
+- STATE 0 = ``OFF`` → hutch **not** secure (search active or
+  broken; PSS will not admit beam).
+- STATE 1 = ``ON``  → hutch secure (searched and locked; PSS
+  permits beam).
+
+These are the predicates the :doc:`../procedures/item_003`
+(``enable_beamline``) stub procedure uses for its
+``beamline_enabled`` postcondition. Both must read ``ON`` before
+the FES open command (``S02BM-PSS:FES:OpenEPICSC``) will be
+honoured.
+
+
 B-station Slits
 ~~~~~~~~~~~~~~~
 

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -53,8 +53,9 @@ procedure is implemented.
 - :doc:`procedures/item_005` — ``set_energy_to_preselect``.
   Satisfies ``energy_configured``.
 - :doc:`procedures/item_006` — ``set_flag_in``. Satisfies
-  ``flag_in_beam``. (Flag itself is a future addition to the
-  hardware inventory.)
+  ``flag_in_beam``. (Flag is ``2bma:m44`` in
+  :doc:`manual/item_020`; energy-dependent target Y from
+  ``energy-decarlof``'s ``energy2bm.json``.)
 - :doc:`procedures/item_007` — ``open_b_shutter``. Satisfies
   ``b_shutter_open``.
 - :doc:`procedures/item_008` — ``set_b_slits``. Satisfies

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -37,6 +37,35 @@ Current procedures
   cora side.
 
 
+Stub procedures (precondition targets of item_002)
+==================================================
+
+These pages exist so the precondition graph of
+:doc:`procedures/item_002` has named targets to link to. Each is a
+STUB — the procedure is named, its Postconditions field declares
+which state it would satisfy, and the rest is TBD until the
+procedure is implemented.
+
+- :doc:`procedures/item_003` — ``enable_beamline``. Satisfies
+  ``beamline_enabled``.
+- :doc:`procedures/item_004` — ``set_a_slits``. Satisfies
+  ``a_slits_open``.
+- :doc:`procedures/item_005` — ``set_energy_to_preselect``.
+  Satisfies ``energy_configured``.
+- :doc:`procedures/item_006` — ``set_flag_in``. Satisfies
+  ``flag_in_beam``. (Flag itself is a future addition to the
+  hardware inventory.)
+- :doc:`procedures/item_007` — ``open_b_shutter``. Satisfies
+  ``b_shutter_open``.
+- :doc:`procedures/item_008` — ``set_b_slits``. Satisfies
+  ``b_slits_configured``.
+- :doc:`procedures/item_009` — ``move_sample_out_of_beam``.
+  Satisfies ``sample_out_of_beam``.
+- :doc:`procedures/item_010` —
+  ``configure_microscope_for_alignment``. Satisfies
+  ``microscope_configured``.
+
+
 .. toctree::
    :glob:
    :maxdepth: 1

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -55,7 +55,8 @@ procedure is implemented.
 - :doc:`procedures/item_006` — ``set_flag_in``. Satisfies
   ``flag_in_beam``. (Flag is ``2bma:m44`` in
   :doc:`manual/item_020`; energy-dependent target Y from
-  ``energy-decarlof``'s ``energy2bm.json``.)
+  `energy2bm.json
+  <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__.)
 - :doc:`procedures/item_007` — ``open_b_shutter``. Satisfies
   ``b_shutter_open``.
 - :doc:`procedures/item_008` — ``set_b_slits``. Satisfies

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -81,26 +81,79 @@ Devices
 Preconditions
 -------------
 
-The operator is responsible for these before launching:
+In v0.0.1 the operator is responsible for establishing each of the
+states below before launching. As the satisfying procedures land,
+cora's dependency graph will be able to auto-resolve them.
 
-- Beamline is running in white-beam mode (DMM out, filters set
-  for indirect-detection imaging).
-- ``MCTOptics`` IOC is reachable (``2bm:MCTOptics:CameraSelected``
-  and ``LensSelected`` respond).
-- The desired **camera** is selected on the MCTOptics screen
-  (Camera 1 = Oryx 5MP, Camera 2 = Oryx 31MP).
-- The desired **lens** is selected on the MCTOptics screen
-  (Lens1 / Lens2 / Lens3).
-- ``Optique_Peter_focus_Z`` is homed and the Z stage is between
-  200 and 500 mm (the procedure's safety band; runs that ask for
-  values outside this band are rejected at ``__init__``).
-- ``2bmb:table3`` is at a known-good baseline pose.
-- B-station slits are open to a small square aperture (~1 × 1 mm
-  is the design target; the centroid algorithm needs a compact
-  bright region above ``threshold_fraction × max``).
-- Front-end shutter (FES) is **open**.
-- Nobody is in 2-BM-B; PSS interlocks satisfied.
-- Sample stage is in a safe out-of-beam position.
+.. list-table::
+   :header-rows: 1
+   :widths: 22 48 30
+
+   * - State
+     - Predicate (informal)
+     - Satisfied by
+   * - ``beamline_enabled``
+     - Hutches searched and locked; BLEPS clear of Fault; APS
+       delivering beam; FES permit granted.
+     - :doc:`item_003` (``enable_beamline``)
+   * - ``a_slits_open``
+     - A-station slits open with ``H ≥ 0.5 mm`` and ``V ≥ 0.5 mm``
+       (so propagation produces ≈ 1 × 1 mm at the sample / detector
+       plane).
+     - :doc:`item_004` (``set_a_slits``)
+   * - ``energy_configured``
+     - Mirror M1 and DMM driven to the energy-dependent positions
+       in the ``energy`` package's lookup tables.
+     - :doc:`item_005` (``set_energy_to_preselect``)
+   * - ``flag_in_beam``
+     - **Flag** moved to its in-beam Y position. *(Flag is a future
+       addition; placeholder.)*
+     - :doc:`item_006` (``set_flag_in``)
+   * - ``b_shutter_open``
+     - ``S02BM-PSS:SBS:BeamBlockingM == OFF`` (inverted enum — OFF
+       means NOT blocking, i.e. shutter OPEN).
+     - :doc:`item_007` (``open_b_shutter``)
+   * - ``b_slits_configured``
+     - B-station slits at ``H × V = 1.0 × 1.0 mm`` centred on the
+       energy-set vertical Y. Blade motors ``2bma:m9 / m10 / m11
+       / m12``.
+     - :doc:`item_008` (``set_b_slits``)
+   * - ``sample_out_of_beam``
+     - The relevant sample-stack axis (mount-dependent) is at its
+       out-of-beam position.
+     - :doc:`item_009` (``move_sample_out_of_beam``)
+   * - ``microscope_configured``
+     - MCTOptics lens at 1.1× (slot 0); detector optical table
+       ``2bmb:table3.Y`` at the energy-set beam-centre position;
+       Z stage ``2bmbAERO:m1`` at a safe mid-band position
+       (default 300 mm).
+     - :doc:`item_010` (``configure_microscope_for_alignment``)
+   * - **FES shutter is open**
+     - ``S02BM-PSS:FES:BeamBlockingM == OFF`` (inverted enum).
+       Bundled into ``beamline_enabled`` above; called out
+       separately because the FES status is a useful sanity check
+       directly visible on the synoptic.
+     - :doc:`item_003` (``enable_beamline``)
+   * - **Z stage in safety band**
+     - ``200 ≤ 2bmbAERO:m1.RBV ≤ 500`` (mm). Runs that ask for
+       ``z_near`` / ``z_far`` outside this band are rejected at
+       ``__init__``.
+     - operator (manual move) or
+       :doc:`item_010` (``configure_microscope_for_alignment``)
+   * - **MCTOptics IOC reachable**
+     - ``2bm:MCTOptics:CameraSelect`` and ``LensSelect`` respond
+       to ``caget`` (the IOC runs on ``tomdet`` and may not be on
+       the same network as some operator hosts).
+     - operator (start MCTOptics IOC if not running)
+   * - **PSS interlocks satisfied**
+     - Nobody in 2-BM-B; hutch search complete.
+     - operator (floor procedure)
+
+The machine-readable form of this table lives in
+``procedures/detector_z_rail_alignment.py`` as the module-level
+``PRECONDITIONS`` list. It is currently **data only** — the
+procedure does NOT runtime-check these. Cora can ingest the list
+once the schema lands.
 
 
 Operating envelope (v0.0.1 "build trust" phase)

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -179,12 +179,25 @@ Operating envelope (v0.0.1 "build trust" phase)
   ``ArrayCallbacks``), the Z stage RBV, **and** the table soft
   axes ``2bmb:table3.AY`` / ``.AX``. On every exit path the camera
   state and Z position are restored. The table AY/AX are restored
-  **only on non-success exits** (``OperatorAbort``, exception,
-  max-iterations reached without convergence) — on clean
-  convergence the optimised AY/AX are left in place as the
-  procedure's deliberate output. The restore path prints its plan
-  but is **not** gated (it must run even on a panic exit); pass
-  ``--confirm-restore`` to gate it.
+  **only on these exits**:
+
+  - ``OperatorAbort`` (operator answered N at a gate).
+  - Exception (any RuntimeError, including the divergence guard).
+  - max-iterations exhausted **and** the best ``|tilt|`` seen across
+    iterations was no better than the starting state.
+
+  On **clean convergence**, the optimised AY/AX stay in place as
+  the procedure's deliberate output. On **max-iterations with a
+  net improvement** (the common case when the threshold can't be
+  reached because of noise), the procedure moves the table back
+  to the iteration that gave the best ``|tilt|`` ("best-state commit")
+  and leaves it there — the operator still gets the improvement
+  that did happen, instead of losing it to baseline restore. The
+  log clearly states which path was taken.
+
+  The restore path prints its plan but is **not** gated (it must
+  run even on a panic exit); pass ``--confirm-restore`` to gate
+  it.
 
   Caveat: the table restore writes to the ``2bmb:table3.AY/.AX``
   soft PVs; the synApps ``table.db`` kinematic does not always
@@ -233,10 +246,39 @@ Parameters
      - s
      - Per-frame exposure. Default: 0.05.
    * - ``convergence_threshold``
-     - number > 0
+     - number > 0 (or auto)
      - µrad
-     - Residual linear slope at or below which the procedure
-       stops iterating. Default: 5 µrad.
+     - Residual linear slope at or below which the procedure stops
+       iterating. **Default: auto-computed** from the detected lens
+       + binning + dz + a fixed rail-straightness floor (~10 µrad
+       for the PRO225SL over a 300 mm dz), multiplied by
+       ``convergence_safety_margin``. Operator override
+       (``--convergence-urad``) wins; a warning is logged if the
+       override is below the physical noise floor (procedure
+       cannot meaningfully converge to a sub-floor target).
+       Reference values at this beamline (dz=300 mm,
+       bin=2x2, centroid_noise=1 pix):
+
+       - 1.1x (Lens1): noise floor ~21 urad -> auto threshold ~31 urad
+       - 5x   (Lens2): noise floor ~10 urad (straightness floor
+         dominates) -> auto threshold ~15 urad
+       - 10x  (Lens3): noise floor ~10 urad -> auto threshold ~15 urad
+   * - ``convergence_safety_margin``
+     - > 1
+     - ×
+     - Multiplier applied to the noise floor when auto-computing
+       the convergence threshold. Default: 1.5. Larger values
+       converge sooner (less precision); smaller values closer to
+       1.0 push toward the physical floor but may not always
+       reach it given residual centroid jitter.
+   * - ``centroid_noise_pix``
+     - > 0
+     - pixels
+     - Assumed standard deviation of the centroid fit, used only
+       by the auto-threshold calculation. Default: 1.0 (typical
+       for COM on a clean spot above threshold). Increase if the
+       spot is faint / noisy; decrease if a sub-pixel-stable
+       Gaussian fit is in use.
    * - ``max_iterations``
      - integer ≥ 1
      - —
@@ -385,7 +427,7 @@ Steps
        (b) Convert to angular misalignment ``tilt_X``,
        ``tilt_Y`` (µrad).
 
-       (c) **Divergence guard**: if ``|tilt|`` (Euclidean) at
+       (c) **Divergence guard**: if ````|tilt|```` (Euclidean) at
        this iteration exceeds the previous iteration's by more
        than ``divergence_grow_threshold``, raise ``RuntimeError``
        → restore puts table AY/AX back to baseline. Aborts a

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -250,7 +250,9 @@ Parameters
    * - ``exposure_time``
      - number > 0
      - s
-     - Per-frame exposure. Default: 0.05.
+     - Per-frame exposure. Default: 0.2 (gives a clean bright spot
+       on the 1.1× lens at typical 2-BM-B flux). Increase if the
+       centroid signal is weak.
    * - ``convergence_threshold``
      - number > 0 (or auto)
      - µrad

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -108,8 +108,10 @@ cora's dependency graph will be able to auto-resolve them.
        in the ``energy`` package's lookup tables.
      - :doc:`item_005` (``set_energy_to_preselect``)
    * - ``flag_in_beam``
-     - **Flag** moved to its in-beam Y position. *(Flag is a future
-       addition; placeholder.)*
+     - ``2bma:m44`` (Flag Y) at the mode-appropriate position.
+       Pink: ``0 mm`` user. Mono: per ``energy_move_flag`` lookup
+       in ``energy2bm.json`` (~12-23 mm depending on energy;
+       ``0`` at 30+ keV). See item_020's Flag block.
      - :doc:`item_006` (``set_flag_in``)
    * - ``b_shutter_open``
      - ``S02BM-PSS:SBS:BeamBlockingM == OFF`` (inverted enum — OFF

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -146,7 +146,9 @@ cora's dependency graph will be able to auto-resolve them.
        the same network as some operator hosts).
      - operator (start MCTOptics IOC if not running)
    * - **PSS interlocks satisfied**
-     - Nobody in 2-BM-B; hutch search complete.
+     - ``S02BM-PSS:StaA:SecureM == 1`` (ON) AND
+       ``S02BM-PSS:StaB:SecureM == 1`` (ON).
+       See :doc:`../manual/item_020` (PSS hutch search status block).
      - operator (floor procedure)
 
 The machine-readable form of this table lives in

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -110,8 +110,10 @@ cora's dependency graph will be able to auto-resolve them.
    * - ``flag_in_beam``
      - ``2bma:m44`` (Flag Y) at the mode-appropriate position.
        Pink: ``0 mm`` user. Mono: per ``energy_move_flag`` lookup
-       in ``energy2bm.json`` (~12-23 mm depending on energy;
-       ``0`` at 30+ keV). See item_020's Flag block.
+       in `energy2bm.json
+       <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+       (~12-23 mm depending on energy; ``0`` at 30+ keV). See
+       item_020's Flag block.
      - :doc:`item_006` (``set_flag_in``)
    * - ``b_shutter_open``
      - ``S02BM-PSS:SBS:BeamBlockingM == OFF`` (inverted enum — OFF

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -93,8 +93,10 @@ cora's dependency graph will be able to auto-resolve them.
      - Predicate (informal)
      - Satisfied by
    * - ``beamline_enabled``
-     - Hutches searched and locked; BLEPS clear of Fault; APS
-       delivering beam; FES permit granted.
+     - ``StaA:SecureM == ON`` AND ``StaB:SecureM == ON`` AND
+       ``FES:BeamBlockingM == OFF`` AND
+       ``SR-ACIS:2BM:FesPermitM == ON`` (the last aggregates
+       BLEPS + APS machine state into one boolean).
      - :doc:`item_003` (``enable_beamline``)
    * - ``a_slits_open``
      - A-station slits open with ``H ≥ 0.5 mm`` and ``V ≥ 0.5 mm``

--- a/docs/source/procedures/item_003.rst
+++ b/docs/source/procedures/item_003.rst
@@ -1,0 +1,72 @@
+============================================
+Enable beamline for beam
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``beamline_enabled`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``enable_beamline``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **BLEPS** — beamline equipment
+  protection system, prerequisite to admit beam.
+- :doc:`../manual/item_020`: **A-shutter (front-end)** —
+  ``S02BM-PSS:FES`` (the procedure may open this, or rely on
+  :doc:`item_007` for the B-shutter side).
+- 2-BM PSS — personnel safety system, hutch search state.
+- APS machine ops — beam in storage ring.
+
+
+Preconditions
+-------------
+
+- TBD. Likely includes: hutches searched and locked, BLEPS clear of
+  Fault, APS top-up in progress, no scheduled beam dump.
+
+
+Parameters
+----------
+
+- TBD.
+
+
+Steps
+-----
+
+- TBD.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``beamline_enabled``
+:Predicate: TBD — no single PV today; depends on BLEPS status
+   register + PSS hutch status + machine-state PV. Likely requires
+   a composite predicate.
+
+
+Failure modes
+-------------
+
+- TBD.
+
+
+Notes
+-----
+
+This is a high-level orchestration procedure that itself probably
+breaks down into sub-procedures (clear BLEPS faults, search hutch,
+open FES, etc.). The intent of this stub is to give the precondition
+graph of :doc:`item_002` a target to point at; the real procedure
+likely lives at the floor-coordinator / OBS-shift level.

--- a/docs/source/procedures/item_003.rst
+++ b/docs/source/procedures/item_003.rst
@@ -51,17 +51,23 @@ Postconditions
 --------------
 
 :Satisfies: ``beamline_enabled``
-:Predicate: Composite. The PSS components are concrete; the BLEPS
-   and machine-state components are TBD.
+:Predicate: Composite, all concrete:
 
    - ``S02BM-PSS:StaA:SecureM == 1`` (``ON`` — 2-BM-A hutch
      searched and locked; see :doc:`../manual/item_020`).
    - ``S02BM-PSS:StaB:SecureM == 1`` (``ON`` — 2-BM-B hutch
      searched and locked).
    - ``S02BM-PSS:FES:BeamBlockingM == 0`` (``OFF`` — FES open;
-     same inverted-enum convention documented in item_020).
-   - BLEPS status: TBD (Fault register clear).
-   - Machine state: TBD (APS storage ring delivering beam).
+     same inverted-enum convention as the other shutter status
+     PVs in item_020).
+   - ``SR-ACIS:2BM:FesPermitM == 1`` (``ON`` — ACIS upstream
+     permit. Aggregates storage-ring health, injection state,
+     APS-wide permits, and the BLEPS fault chain into one
+     boolean. See item_020's ACIS upstream-permit block).
+
+   The ACIS permit replaces what was previously a separate
+   "BLEPS-clear" and "APS-machine-state" pair of TBDs — ACIS
+   composes both upstream.
 
 
 Failure modes

--- a/docs/source/procedures/item_003.rst
+++ b/docs/source/procedures/item_003.rst
@@ -51,9 +51,17 @@ Postconditions
 --------------
 
 :Satisfies: ``beamline_enabled``
-:Predicate: TBD — no single PV today; depends on BLEPS status
-   register + PSS hutch status + machine-state PV. Likely requires
-   a composite predicate.
+:Predicate: Composite. The PSS components are concrete; the BLEPS
+   and machine-state components are TBD.
+
+   - ``S02BM-PSS:StaA:SecureM == 1`` (``ON`` — 2-BM-A hutch
+     searched and locked; see :doc:`../manual/item_020`).
+   - ``S02BM-PSS:StaB:SecureM == 1`` (``ON`` — 2-BM-B hutch
+     searched and locked).
+   - ``S02BM-PSS:FES:BeamBlockingM == 0`` (``OFF`` — FES open;
+     same inverted-enum convention documented in item_020).
+   - BLEPS status: TBD (Fault register clear).
+   - Machine state: TBD (APS storage ring delivering beam).
 
 
 Failure modes

--- a/docs/source/procedures/item_004.rst
+++ b/docs/source/procedures/item_004.rst
@@ -1,0 +1,63 @@
+============================================
+Set A-station slit aperture
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``a_slits_open`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``set_a_slits``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **A-station slits** — the upstream
+  beam-shaping slits whose downstream propagation produces the
+  ~1 × 1 mm beam at sample / detector. Blade motors and composite
+  Size/Centre PVs documented in item_020's A-station section.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+
+
+Parameters
+----------
+
+- ``size_h_mm`` (number > 0) — horizontal aperture. Default for
+  ``detector_z_rail_alignment``: 0.5 mm (so that propagation to the
+  detector produces ≈ 1 × 1 mm at the sample / detector plane).
+- ``size_v_mm`` (number > 0) — vertical aperture. Default: 0.5 mm.
+- ``center_h_mm`` / ``center_v_mm`` (optional) — re-centring.
+
+
+Steps
+-----
+
+- TBD. Drive blade motors or write composite Size PVs; wait for
+  DMOV.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``a_slits_open``
+:Predicate: ``A_slit_H_size_RBV >= 0.5`` AND
+   ``A_slit_V_size_RBV >= 0.5`` (PV names TBD —
+   see item_020's A-station block).
+
+
+Failure modes
+-------------
+
+- TBD.

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -1,0 +1,65 @@
+============================================
+Set energy to preselect
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``energy_configured`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``set_energy_to_preselect``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **Mirror M1** and **DMM** — drives both
+  optics to the energy-dependent positions in a coordinated move.
+- The reference implementation lives in the ``energy`` package at
+  https://github.com/xray-imaging/energy (local checkout under
+  ``~/conda/energy-decarlof``).
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+- :doc:`item_007` (``open_b_shutter``) — beam must reach the optics
+  to verify the energy change.
+
+
+Parameters
+----------
+
+- ``energy_keV`` (number > 0) — target energy. Default for
+  ``detector_z_rail_alignment``: TBD (whichever preselect the
+  experiment is running on).
+
+
+Steps
+-----
+
+- TBD. Delegate to the ``energy`` package
+  (``energy.change_energy(keV)``); wait for mirror + DMM motors to
+  settle.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``energy_configured``
+:Predicate: Mirror M1 and DMM RBVs match the energy-dependent
+   lookup tables in the ``energy`` package (predicate is
+   energy-parameterised — needs current energy as input).
+
+
+Failure modes
+-------------
+
+- TBD.

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -22,8 +22,11 @@ Devices
 - :doc:`../manual/item_020`: **Mirror M1** and **DMM** — drives both
   optics to the energy-dependent positions in a coordinated move.
 - The reference implementation lives in the ``energy`` package at
-  https://github.com/xray-imaging/energy (local checkout under
-  ``~/conda/energy-decarlof``).
+  https://github.com/xray-imaging/energy. The mono-energy
+  lookup table is at
+  https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json
+  (used by :doc:`item_006` for the energy-dependent flag Y and by
+  :doc:`item_008` for the energy-dependent B-slit Y).
 
 
 Preconditions

--- a/docs/source/procedures/item_006.rst
+++ b/docs/source/procedures/item_006.rst
@@ -1,0 +1,63 @@
+============================================
+Move flag into beam
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``flag_in_beam`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+   The **flag** is a downstream element scheduled to be added to
+   the 2-BM beamline. It is not yet present in
+   :doc:`../manual/item_020` — this stub records the precondition
+   slot so that the procedure graph for ``detector_z_rail_alignment``
+   has a target to point at. Replace the placeholders below once the
+   flag is installed.
+
+
+Name
+----
+
+``set_flag_in``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **Flag** (TBD — not yet in the
+  hardware inventory). Single-axis Y motion.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+
+
+Parameters
+----------
+
+- ``flag_y_mm`` (number) — Y position for in-beam state. Default:
+  TBD.
+
+
+Steps
+-----
+
+- TBD. Move flag Y motor to in-beam position; wait for DMOV.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``flag_in_beam``
+:Predicate: ``Flag_Y_RBV`` within tolerance of ``flag_y_mm``
+   (PV name TBD).
+
+
+Failure modes
+-------------
+
+- TBD.

--- a/docs/source/procedures/item_006.rst
+++ b/docs/source/procedures/item_006.rst
@@ -31,9 +31,9 @@ Preconditions
 - :doc:`item_003` (``enable_beamline``).
 - For mono mode: :doc:`item_005`
   (``set_energy_to_preselect``) — the target flag Y depends on
-  the current DMM energy via the
-  ``energy_move_flag`` lookup in
-  ``energy-decarlof/src/energy/data/energy2bm.json``.
+  the current DMM energy via the ``energy_move_flag`` lookup in
+  `energy2bm.json
+  <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__.
 
 
 Parameters
@@ -46,9 +46,10 @@ Parameters
 
   - ``pink``: ``flag_y_mm = 0`` (lower position, out of beam).
   - ``mono``: ``flag_y_mm = energy_move_flag[current_energy_keV]``
-    (read from ``energy2bm.json``). Indicative values:
-    13.374 keV → 23 mm, 18 keV → 17 mm, 20 keV → 15 mm,
-    25 keV → 12 mm, 30+ keV → 0 mm.
+    (read from `energy2bm.json
+    <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__).
+    Indicative values: 13.374 keV → 23 mm, 18 keV → 17 mm,
+    20 keV → 15 mm, 25 keV → 12 mm, 30+ keV → 0 mm.
 
 
 Steps
@@ -72,9 +73,10 @@ Failure modes
 
 - Motor fault on ``2bma:m44`` — check the motor record's status
   and clear before retrying.
-- For mono mode: ``energy2bm.json`` has no entry for the current
-  DMM energy — operator must either calibrate the lookup or pass
-  ``flag_y_mm`` explicitly.
+- For mono mode: `energy2bm.json
+  <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+  has no entry for the current DMM energy — operator must either
+  calibrate the lookup or pass ``flag_y_mm`` explicitly.
 - Range check fails — typically operator misread mm vs encoded
   units; verify against the ``meters_all.adl`` MEDM screen.
 

--- a/docs/source/procedures/item_006.rst
+++ b/docs/source/procedures/item_006.rst
@@ -1,20 +1,14 @@
 ============================================
-Move flag into beam
+Move flag into beam (mode-dependent)
 ============================================
 
 .. warning::
 
    **STATUS: STUB.** Placeholder for the procedure that satisfies
    the precondition ``flag_in_beam`` of :doc:`item_002`
-   (``detector_z_rail_alignment``). To be fleshed out as the
-   procedure is implemented.
-
-   The **flag** is a downstream element scheduled to be added to
-   the 2-BM beamline. It is not yet present in
-   :doc:`../manual/item_020` — this stub records the precondition
-   slot so that the procedure graph for ``detector_z_rail_alignment``
-   has a target to point at. Replace the placeholders below once the
-   flag is installed.
+   (``detector_z_rail_alignment``). The flag is now in the
+   :doc:`../manual/item_020` inventory (as ``2bma:m44``); the
+   procedure that orchestrates it is what's still TBD.
 
 
 Name
@@ -26,38 +20,71 @@ Name
 Devices
 -------
 
-- :doc:`../manual/item_020`: **Flag** (TBD — not yet in the
-  hardware inventory). Single-axis Y motion.
+- :doc:`../manual/item_020`: **Flag (diagnostic phosphor)** —
+  single vertical (Y) motor ``2bma:m44``. User/dial offset:
+  ``user = dial - 5`` mm. User-coord limits: -4.5 to +35.0 mm.
 
 
 Preconditions
 -------------
 
 - :doc:`item_003` (``enable_beamline``).
+- For mono mode: :doc:`item_005`
+  (``set_energy_to_preselect``) — the target flag Y depends on
+  the current DMM energy via the
+  ``energy_move_flag`` lookup in
+  ``energy-decarlof/src/energy/data/energy2bm.json``.
 
 
 Parameters
 ----------
 
-- ``flag_y_mm`` (number) — Y position for in-beam state. Default:
-  TBD.
+- ``mode`` (enum: ``pink`` | ``mono``) — beamline mode. Default:
+  derived from current DMM state (out = pink, in = mono).
+- ``flag_y_mm`` (number, user coord) — explicit target Y. If
+  not given, derive from ``mode``:
+
+  - ``pink``: ``flag_y_mm = 0`` (lower position, out of beam).
+  - ``mono``: ``flag_y_mm = energy_move_flag[current_energy_keV]``
+    (read from ``energy2bm.json``). Indicative values:
+    13.374 keV → 23 mm, 18 keV → 17 mm, 20 keV → 15 mm,
+    25 keV → 12 mm, 30+ keV → 0 mm.
 
 
 Steps
 -----
 
-- TBD. Move flag Y motor to in-beam position; wait for DMOV.
+1. Determine target Y from ``mode`` + (if mono) energy lookup.
+2. Range check: ``-4.5 ≤ flag_y_mm ≤ 35.0``.
+3. ``move_motor 2bma:m44 <flag_y_mm>``; wait for DMOV.
 
 
 Postconditions
 --------------
 
 :Satisfies: ``flag_in_beam``
-:Predicate: ``Flag_Y_RBV`` within tolerance of ``flag_y_mm``
-   (PV name TBD).
+:Predicate: ``2bma:m44.RBV`` within motor tolerance of the
+   commanded ``flag_y_mm``.
 
 
 Failure modes
 -------------
 
-- TBD.
+- Motor fault on ``2bma:m44`` — check the motor record's status
+  and clear before retrying.
+- For mono mode: ``energy2bm.json`` has no entry for the current
+  DMM energy — operator must either calibrate the lookup or pass
+  ``flag_y_mm`` explicitly.
+- Range check fails — typically operator misread mm vs encoded
+  units; verify against the ``meters_all.adl`` MEDM screen.
+
+
+Notes
+-----
+
+In ``detector_z_rail_alignment`` (v0.0.1) the procedure assumes
+the flag is already in the appropriate position for the running
+mode. If pink-beam alignment is being done, the operator should
+have driven ``2bma:m44`` to 0 mm beforehand. The
+``set_flag_in`` procedure formalises that step so cora's
+dependency graph can resolve it.

--- a/docs/source/procedures/item_007.rst
+++ b/docs/source/procedures/item_007.rst
@@ -1,0 +1,60 @@
+============================================
+Open B-shutter (P6-50 Safety Shutter)
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``b_shutter_open`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``open_b_shutter``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **P6-50 Safety Shutter (B-shutter)** —
+  ``S02BM-PSS:SBS``. Open command ``OpenEPICSC``; close command
+  ``CloseEPICSC``; status readback ``S02BM-PSS:SBS:BeamBlockingM``.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``) — PSS must permit the open.
+
+
+Parameters
+----------
+
+- (none)
+
+
+Steps
+-----
+
+1. ``caput S02BM-PSS:SBS:OpenEPICSC 1``.
+2. Wait for ``S02BM-PSS:SBS:BeamBlockingM`` to read ``OFF``
+   (STATE 0; **inverted enum** — OFF means NOT blocking → shutter
+   OPEN). See :doc:`../manual/item_020` for the semantic note.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``b_shutter_open``
+:Predicate: ``S02BM-PSS:SBS:BeamBlockingM == 0`` (i.e. ``OFF``).
+
+
+Failure modes
+-------------
+
+- ``BeamBlockingM`` does not transition to ``OFF`` within the
+  timeout — PSS permit not granted, hardware fault, or BLEPS
+  Fault latched. Verify upstream interlocks; do not retry blindly.

--- a/docs/source/procedures/item_008.rst
+++ b/docs/source/procedures/item_008.rst
@@ -1,0 +1,69 @@
+============================================
+Set B-station slits for alignment
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``b_slits_configured`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``set_b_slits``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **B-station slits** — blade motors
+  ``2bma:m9 / m10`` (vertical pair) and ``2bma:m11 / m12``
+  (horizontal pair). Composite Size / Centre PVs may not be
+  published; drive blades directly and derive size = blade₁ − blade₂
+  and centre = (blade₁ + blade₂) / 2.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+- :doc:`item_005` (``set_energy_to_preselect``) — the slit-centre Y
+  is energy-dependent (DMM offsets the beam vertically).
+
+
+Parameters
+----------
+
+- ``size_h_mm`` (number > 0) — horizontal aperture. Default for
+  ``detector_z_rail_alignment``: 1.0 mm.
+- ``size_v_mm`` (number > 0) — vertical aperture. Default: 1.0 mm.
+- ``center_v_mm`` (number) — vertical centre, energy-dependent.
+  Read from energy-package lookup. Default: TBD.
+- ``center_h_mm`` (number, optional) — horizontal centre. Default:
+  current value (don't re-centre).
+
+
+Steps
+-----
+
+- TBD. Compute blade targets from size + centre; drive each blade;
+  wait for all four DMOV.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``b_slits_configured``
+:Predicate: ``|2bma:m12 - 2bma:m11 - size_h| < ε``,
+   ``|2bma:m9 - 2bma:m10 - size_v| < ε``, centre PVs likewise
+   within tolerance.
+
+
+Failure modes
+-------------
+
+- One or more blades does not reach target — check motor faults on
+  ``2bma:m9–m12`` motor records.

--- a/docs/source/procedures/item_009.rst
+++ b/docs/source/procedures/item_009.rst
@@ -1,0 +1,64 @@
+============================================
+Move sample out of beam
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``sample_out_of_beam`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``move_sample_out_of_beam``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **Sample stack** — the relevant lateral
+  axis depends on the sample mount. Typically one of
+  ``Sample_top_X`` (``2bmb:m18``), ``Sample_top_Z`` (``2bmb:m17``),
+  the hexapod X/Y axes (``2bmHXP:m1 / m2``), or the sample optical
+  table Y (``2bmb:m24``).
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+
+
+Parameters
+----------
+
+- ``out_of_beam_position`` (per-axis, mm) — TBD.
+- ``axis`` (which sample-stack axis to move) — TBD; depends on
+  current mount.
+
+
+Steps
+-----
+
+- TBD. Drive selected sample-stack axis to out-of-beam position;
+  wait for DMOV.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``sample_out_of_beam``
+:Predicate: TBD — depends on which axis was moved. Typically a
+   per-axis ``.RBV`` test against the out-of-beam position with
+   tolerance.
+
+
+Failure modes
+-------------
+
+- Sample mount has not been characterised for "out of beam" —
+  operator must define the position manually.
+- Motor fault on the chosen axis.

--- a/docs/source/procedures/item_010.rst
+++ b/docs/source/procedures/item_010.rst
@@ -1,0 +1,84 @@
+============================================
+Configure microscope for alignment
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** Placeholder for the procedure that satisfies
+   the precondition ``microscope_configured`` of :doc:`item_002`
+   (``detector_z_rail_alignment``). To be fleshed out as the
+   procedure is implemented.
+
+
+Name
+----
+
+``configure_microscope_for_alignment``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **MCTOptics** — drives lens / camera
+  selection via ``2bm:MCTOptics:LensSelect`` and
+  ``2bm:MCTOptics:CameraSelect``.
+- :doc:`../manual/item_020`: **Detector optical table** —
+  ``2bmb:table3``; the ``.Y`` translation axis sets the table
+  vertical position so the X-ray beam lands on the camera centre.
+- :doc:`../manual/item_020`: **Optique Peter Z stage** —
+  ``2bmbAERO:m1``; pre-positioned to a safe mid-band Z before the
+  alignment procedure runs.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+- :doc:`item_005` (``set_energy_to_preselect``) — beam Y at detector
+  depends on energy (via DMM offset).
+
+
+Parameters
+----------
+
+- ``lens_index`` (integer 0–2) — MCTOptics lens slot. Default for
+  ``detector_z_rail_alignment``: 0 (1.1× wide-field lens).
+- ``detector_table_y_mm`` (number) — table Y to centre the beam on
+  the camera. Energy-dependent; default TBD.
+- ``z_park_mm`` (number) — initial Z position for the Optique Peter
+  rail. Default: 300 mm (mid of the 200–500 mm safety band used by
+  :doc:`item_002`).
+
+
+Steps
+-----
+
+- TBD. Set MCTOptics LensSelect; wait for LensSelected to match.
+  Move ``2bmb:table3.Y`` to target; wait for jacks.
+  Move ``2bmbAERO:m1`` to z_park; wait for DMOV.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``microscope_configured``
+:Predicate: ``2bm:MCTOptics:LensSelect == lens_index`` AND
+   ``2bmb:table3.Y`` within tolerance of ``detector_table_y_mm`` AND
+   ``2bmbAERO:m1.RBV`` within tolerance of ``z_park_mm``.
+
+
+Failure modes
+-------------
+
+- TBD.
+
+
+Notes
+-----
+
+In ``detector_z_rail_alignment`` (v0.0.1) the procedure does NOT
+modify lens / camera selection — it reads whatever MCTOptics is
+currently set to and adapts. This precondition exists for cora's
+dependency graph: it captures the assumption that the operator
+(or this procedure) has already put MCTOptics into a known state
+before the Z-rail alignment runs.


### PR DESCRIPTION
## Summary

Seven commits on top of #164. Two themes:

1. **Make the `detector_z_rail_alignment` precondition graph explicit**
   so cora can ingest the dependency structure. New `Preconditions`
   table in `item_002.rst` (State / Predicate / Satisfied-by, 12
   rows). Eight new stub procedures (items 003-010), one per
   precondition that has a dedicated satisfying procedure.

2. **Fill in concrete PVs that turned out to exist** for predicates
   previously marked TBD: PSS hutch search (`StaA/StaB:SecureM`),
   ACIS upstream permit (`SR-ACIS:2BM:FesPermitM`), Flag
   (`2bma:m44` with the energy-dependent Y lookup table from the
   `energy` package). Also documents the design changes that landed
   in the `decarlof/2bm-procedures` companion repo: auto-threshold
   from lens/binning/dz, commit-to-best on max-iter, exposure-time
   default tuned from live-run feedback.

## Files

| File | Change |
|------|--------|
| `manual/item_020.rst` | +129 lines: PSS hutch search status PVs, ACIS upstream permit PV, Flag (2bma:m44) component block with energy-dependent Y table |
| `procedures.rst` | Index gains a "Stub procedures" subsection listing items 003-010 with their satisfies-state |
| `procedures/item_002.rst` | Preconditions section becomes a 12-row State/Predicate/Satisfied-by table; parameters table gains auto-threshold + commit-to-best documentation |
| `procedures/item_003.rst` | NEW stub: `enable_beamline` (predicate now fully concrete: StaA + StaB + FES + ACIS) |
| `procedures/item_004.rst` | NEW stub: `set_a_slits` |
| `procedures/item_005.rst` | NEW stub: `set_energy_to_preselect`; links to upstream `energy` package |
| `procedures/item_006.rst` | NEW stub: `set_flag_in` (real PV 2bma:m44 + energy-dependent Y from `energy2bm.json`) |
| `procedures/item_007.rst` | NEW stub: `open_b_shutter` (predicate concrete via SBS:BeamBlockingM) |
| `procedures/item_008.rst` | NEW stub: `set_b_slits` |
| `procedures/item_009.rst` | NEW stub: `move_sample_out_of_beam` |
| `procedures/item_010.rst` | NEW stub: `configure_microscope_for_alignment` |

Totals: **+882 lines, -31 lines across 11 files (10 new files)**.

## New beamline-component PV documentation in `item_020.rst`

- **PSS hutch search status** -- `S02BM-PSS:StaA:SecureM` and
  `S02BM-PSS:StaB:SecureM` (read-only `DBF_ENUM`, hosted on
  `s2pvgate`). STATE 0 OFF = hutch NOT secure; STATE 1 ON = hutch
  searched and locked (PSS permits beam).
- **ACIS upstream permit** -- `SR-ACIS:2BM:FesPermitM`. One PV that
  aggregates storage-ring health, injection state, APS-wide
  permits, the per-beamline PSS state, and the BLEPS fault chain
  into a single boolean. Replaces what would otherwise be a
  multi-PV BLEPS register lookup + machine-state check.
- **Flag (diagnostic phosphor)** -- vertical Y stage `2bma:m44` at
  z ~20.6 m from source, with a visible-light camera looking at
  it. User-dial offset (user = dial - 5), full energy-to-flag-Y
  table from
  https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json
  (key `energy_move_flag`): 13 keV -> 23 mm, 18 keV -> 17 mm,
  20 keV -> 15 mm, 25 keV -> 12 mm, 30+ keV -> 0 mm. Pink-beam
  mode parks at 0 mm.

## Precondition graph for `detector_z_rail_alignment` (item_002.rst)

The `Preconditions` section was a prose list; now it's a 12-row
table. Each row pairs a `state` identifier with a concrete-or-TBD
predicate and a link to the procedure (or operator) that
establishes it:

| State | Predicate (informal) | Satisfied by |
|-------|----------------------|--------------|
| `beamline_enabled` | `StaA:SecureM==ON` AND `StaB:SecureM==ON` AND `FES:BeamBlockingM==OFF` AND `SR-ACIS:2BM:FesPermitM==ON` | item_003 |
| `a_slits_open` | A-slits H>=0.5 mm AND V>=0.5 mm | item_004 |
| `energy_configured` | Mirror M1 + DMM at energy-dependent positions per `energy2bm.json` | item_005 |
| `flag_in_beam` | `2bma:m44` at mode-appropriate position (pink: 0; mono: per `energy_move_flag` lookup) | item_006 |
| `b_shutter_open` | `SBS:BeamBlockingM == 0 (OFF)` (inverted enum: OFF = open) | item_007 |
| `b_slits_configured` | B-slits 1.0x1.0 mm centred on energy-set Y | item_008 |
| `sample_out_of_beam` | mount-dependent | item_009 |
| `microscope_configured` | MCTOptics lens slot 0; table.Y at beam centre; Z in band | item_010 |
| FES open | `FES:BeamBlockingM == 0` | bundled into item_003 |
| Z in safety band | `200 <= 2bmbAERO:m1.RBV <= 500` | operator or item_010 |
| MCTOptics IOC reachable | `caget 2bm:MCTOptics:CameraSelect` succeeds | operator |
| PSS interlocks satisfied | `StaA + StaB SecureM == ON` (subset of beamline_enabled) | operator |

The matching machine-readable list (`PRECONDITIONS` Python module
constant in `decarlof/2bm-procedures`) is updated in lock-step so
cora can ingest the same predicates without re-parsing the RST.

## item_002.rst other updates (from companion repo design changes)

- **Auto-computed convergence threshold** -- new parameter behaviour:
  `--convergence-urad` defaults to None, in which case the
  procedure resolves the threshold from lens + binning + dz + rail
  straightness floor x safety margin. Reference values per lens
  documented in-page (1.1x ~31 urad, 5x/10x ~15 urad). New
  parameters: `convergence_safety_margin`, `centroid_noise_pix`.
- **Best-state commit on max-iterations** -- the
  Snapshot+restore block now documents the three exit paths
  (clean convergence keeps current pose; max-iter-with-improvement
  commits the best-seen pose; max-iter-without-improvement
  restores baseline). Previous behaviour discarded any partial
  improvement.

## 8 stub procedures (items 003-010)

Each stub is a copy of the `item_001` template with:

- **Name** filled in.
- **Devices** linked to the relevant `item_020` block.
- **Postconditions** declares which state the procedure satisfies
  and the predicate it tests (concrete PV expression where the PV
  is known; "TBD" otherwise -- always with a note about what the
  satisfying check looks like).
- **Preconditions**, **Parameters**, **Steps**, **Failure modes**
  marked TBD until the procedure is implemented.
- A `STATUS: STUB` warning at the top so readers know the page is
  scaffolding, not finished docs.

Three are nearly populated because the satisfying PV interface is
known today:

- `item_003` enable_beamline -- predicate is fully concrete (4
  PVs) even though the orchestration is TBD.
- `item_007` open_b_shutter -- Steps section is written out as
  an example of what a populated stub looks like (caput
  SBS:OpenEPICSC, wait for BeamBlockingM == OFF).
- `item_006` set_flag_in -- Parameters and Steps populated with
  the energy-dependent lookup.

## Companion repo

The executable implementation lives in
`decarlof/2bm-procedures`. Every doc change in this PR has a
matching code commit there (PRECONDITIONS data list, auto-
threshold computation, best-state tracking, restore reordering
with table-first priority, cumulative divergence guard,
condition-number warning). Procedure is exercised live on
2-BM-B; sensitivity-matrix calibration converges; iteration
produces measurable alignment improvement (best run: 91%
reduction in |tilt| over 10 iterations).

## Test plan

- [ ] `make html` builds cleanly with no warnings on the new
  files (4 pre-existing warnings on unrelated `pre_apsu/ops/*`
  files remain).
- [ ] Cross-references from item_002 -> item_003 through item_010
  all resolve.
- [ ] Cross-references from item_020 (PSS hutch search, ACIS,
  Flag blocks) -> item_002, item_003, item_006 resolve.
- [ ] energy2bm.json URL points at upstream main branch and is
  reachable.

## Commits

| SHA | Subject |
|-----|---------|
| `fe9218f` | docs: match procedures exposure_time default 0.2 s |
| `b1dc5ab` | docs: link energy2bm.json references to the upstream URL |
| `529c08c` | docs: add Flag (2bma:m44) as a component; populate item_006 |
| `b3d41bc` | docs: ACIS upstream permit PV; collapse BLEPS+machine into one read |
| `1af9c9f` | docs(procedures): auto-threshold + commit-to-best behaviour |
| `3334f8b` | docs: add PSS hutch search status PVs; wire into item_003 + item_002 |
| `785d2c5` | docs(procedures): structured Preconditions table + 8 stubs for item_002 |

