### PR TITLE
docs: item_011 + item_012 procedure specs, item_020 cora-readiness + Flag fix

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -245,6 +245,23 @@ L3 Slits
 :EPICS prefix: ``2bma:`` (horizontal motors ``m14`` for A Slit X−
    [inboard], ``m13`` for A Slit X+ [outboard]; vertical motors
    ``m15`` for A Slit Y+ [up], ``m16`` for A Slit Y− [down])
+:Virtual motor PVs (composite Size/Centre): the four ``ao``-record
+   PVs below drive both blades of a pair together. Hosted on
+   ``ioc2bmb1.xray.aps.anl.gov:5064`` (the same IOC that hosts the
+   B-station slit calc records, despite the ``2bma:`` prefix on
+   both). These are the PVs the ``2slit.adl`` MEDM screen wires
+   to the ``Size`` and ``Center`` text-entry boxes; the values you
+   set on the screen propagate through downstream calc records to
+   the individual blade motors.
+
+   =========================  ======================  =====================
+   PV                         Role                    Limits (HOPR / LOPR)
+   =========================  ======================  =====================
+   ``2bma:Slit1Hsize``        Horizontal aperture mm  +93.95 / -24.05
+   ``2bma:Slit1Hcenter``      Horizontal centre mm    +34.73 / -24.27
+   ``2bma:Slit1Vsize``        Vertical aperture mm    +71.29 / -66.71
+   ``2bma:Slit1Vcenter``      Vertical centre mm      +23.47 / -45.53
+   =========================  ======================  =====================
 
 The slits at 2-BM are standard APS L3-20. Technical as-built drawings
 are available `here <https://anl.box.com/s/sgmoux6db8tsx71pvifzkf2ajopfidqx>`_.
@@ -780,9 +797,10 @@ B-station Slits
    Y+ [up] and ``2bma:m10`` for Y− [down])
 :Virtual motor PVs (composite Size/Centre): the four ``ao``-record
    PVs below drive both blades of a pair together. Hosted on
-   ``ioc2bmb1.xray.aps.anl.gov:5064`` despite the ``2bma:`` prefix.
-   These are the PVs the ``2slit.adl`` MEDM screen wires to the
-   ``Size`` and ``Center`` text-entry boxes; the ``Size`` /
+   ``ioc2bmb1.xray.aps.anl.gov:5064`` (the same IOC that hosts the
+   A-station slit calc records, despite the ``2bma:`` prefix on
+   both). These are the PVs the ``2slit.adl`` MEDM screen wires
+   to the ``Size`` and ``Center`` text-entry boxes; the ``Size`` /
    ``Center`` values you set on the screen propagate through
    downstream calc records to the individual blade motors.
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -48,6 +48,7 @@ z = 56764 at the photon stop)::
      -> L3 Slits + Filters             (z = 25225 mm)
      -> Y3-30 Mirror                   (z = 27626 mm)
      -> Double Multilayer Mono (DMM)   (z = 29335 / 29934 mm)
+     -> Flag (diagnostic phosphor)     (z = 32500 mm)
      -> B-shutter (P6-50 Safety)       (z = 33343 mm)
      -> B-station Slits (L3-style)     (z = 50500 mm; in 2-BM-B)
      -> Sample stack                   (in 2-BM-B; optical table + tower)
@@ -215,65 +216,6 @@ A-shutter (front-end)
    front-end / beam-conditioning band stays in cora's Pending
    list); the controller Asset ships in isolation as the
    addressability handle for "controller-level" Procedures.
-
-Flag (diagnostic phosphor)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Role: Diagnostic phosphor screen on a vertical stage. A visible-
-   light camera looks at it so operators can see the X-ray beam
-   position and gauge intensity. In pink-beam (white-beam) mode
-   the flag is parked at its lower limit (``Y = 0 mm`` user,
-   ``5 mm`` dial) -- out of the beam. In mono mode the flag is
-   raised to block the M1-scattered halo while letting the
-   monochromatic beam pass; the exact Y is energy-dependent.
-:Family: Diagnostic (no cora Family declared yet; this is the
-   first instance of a "viewable beam diagnostic" on the 2-BM
-   inventory).
-:Mounted on: Own stand in 2-BM-A (floor-referenced).
-:Carries: phosphor-painted flag + visible camera (not modelled
-   here; the camera is its own Asset).
-:z position: ~20.6 m from source (upstream of the L3 Slits).
-   Not separately listed in the APS reference table.
-:EPICS: ``2bma:m44`` -- single vertical (Y) motor.
-:User/dial offset: user = dial - 5 mm. Limits (user, from
-   ``meters_all.adl``): -4.5 to +35.0 mm (dial 0.5 to 40.0 mm).
-
-The energy-dependent flag positions used by mono-beam scans are
-defined in the ``energy`` package's lookup table
-(`energy2bm.json
-<https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__,
-key ``energy_move_flag``):
-
-==============  ===================  ==========================
-DMM energy keV  Flag Y (mm, user)    Comment
-==============  ===================  ==========================
-13.374          23.0                 highest (low energy)
-13.574          22.0
-18.000          17.0
-20.000          15.0
-25.000          12.0
-25.584          12.0
-30.000          0.0                  flag down (out of beam)
-40.000          0.0
-50.000          0.0
-60.000          0.0                  highest energy
-==============  ===================  ==========================
-
-Pink-beam mode: flag at ``Y = 0 mm`` (user) -- same as the
-"flag down" position used by mono at 30 keV and above.
-
-.. note::
-
-   **Procedures that command this component.**
-   :doc:`../procedures/item_006` (``set_flag_in``) is the stub
-   that satisfies the ``flag_in_beam`` precondition of
-   :doc:`../procedures/item_002` (``detector_z_rail_alignment``).
-   The energy-dependent target Y is read from the
-   ``energy_move_flag`` field of `energy2bm.json
-   <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__;
-   operating in
-   pink mode means writing ``0 mm`` user to ``2bma:m44``.
-
 
 L3 Slits
 ~~~~~~~~
@@ -607,6 +549,64 @@ and ``USY IB``); their average sets the upstream tank Y position and
 their difference produces a Z-tilt around the beam axis. The second
 crystal is positioned relative to the first via the ``DSY`` (Y),
 ``M2 Z`` (along beam), and ``M2 Y`` motors.
+
+Flag (diagnostic phosphor)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Role: Diagnostic phosphor screen on a vertical stage. A visible-
+   light camera looks at it so operators can see the X-ray beam
+   position and gauge intensity. In pink-beam (white-beam) mode
+   the flag is parked at its lower limit (``Y = 0 mm`` user,
+   ``5 mm`` dial) -- out of the beam. In mono mode the flag is
+   raised to block the M1-scattered halo while letting the
+   monochromatic beam pass; the exact Y is energy-dependent.
+:Family: Diagnostic (no cora Family declared yet; this is the
+   first instance of a "viewable beam diagnostic" on the 2-BM
+   inventory).
+:Mounted on: Own stand in 2-BM-A (floor-referenced).
+:Carries: phosphor-painted flag + visible camera (not modelled
+   here; the camera is its own Asset).
+:z position: 32500 mm (between the DMM and the P6-50 safety
+   shutter). Not separately listed in the APS reference table.
+:EPICS: ``2bma:m44`` -- single vertical (Y) motor.
+:User/dial offset: user = dial - 5 mm. Limits (user, from
+   ``meters_all.adl``): -4.5 to +35.0 mm (dial 0.5 to 40.0 mm).
+
+The energy-dependent flag positions used by mono-beam scans are
+defined in the ``energy`` package's lookup table
+(`energy2bm.json
+<https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__,
+key ``energy_move_flag``):
+
+==============  ===================  ==========================
+DMM energy keV  Flag Y (mm, user)    Comment
+==============  ===================  ==========================
+13.374          23.0                 highest (low energy)
+13.574          22.0
+18.000          17.0
+20.000          15.0
+25.000          12.0
+25.584          12.0
+30.000          0.0                  flag down (out of beam)
+40.000          0.0
+50.000          0.0
+60.000          0.0                  highest energy
+==============  ===================  ==========================
+
+Pink-beam mode: flag at ``Y = 0 mm`` (user) -- same as the
+"flag down" position used by mono at 30 keV and above.
+
+.. note::
+
+   **Procedures that command this component.**
+   :doc:`../procedures/item_006` (``set_flag_in``) is the stub
+   that satisfies the ``flag_in_beam`` precondition of
+   :doc:`../procedures/item_002` (``detector_z_rail_alignment``).
+   The energy-dependent target Y is read from the
+   ``energy_move_flag`` field of `energy2bm.json
+   <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__;
+   operating in
+   pink mode means writing ``0 mm`` user to ``2bma:m44``.
 
 P6-50 Safety Shutter (B-shutter)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -227,7 +227,15 @@ L3 Slits
    Family. Standard APS L3-20 four-blade slits — two horizontal
    (X−, X+) and two vertical (Y−, Y+) blade motors, plus per-
    direction derived ``Size`` / ``Center`` calc axes.)
+:cora Asset: ``A_station_slits`` (proposed name; not yet registered.
+   Used as the ``target_asset_ids`` value by ``calibrate_slit_blade_throw``
+   (:doc:`../procedures/item_012`) and by ``centre_and_close_slits``
+   (:doc:`../procedures/item_011`).)
 :Mounted on: Front-end stand (floor-referenced)
+:Driven by: ``OMS_VME58_2bma_drive`` (cora ``MotionController`` Asset
+   already registered in ``cora/docs/deployments/2-bm/assets.md``;
+   pending controller_id back-reference from this Asset once it
+   registers)
 :Carries: (beam conditioning only)
 :z position: 25225 mm (ref 2: centre of optic; shared with Filters)
 :Position tolerance: 250 µm (x, y), 5 mm (z)
@@ -271,6 +279,32 @@ are available `here <https://anl.box.com/s/sgmoux6db8tsx71pvifzkf2ajopfidqx>`_.
    (up) and ``2bma:m16`` for the Y− blade (down). The ``Size`` and
    ``Center`` columns are calc-driven composites that move both
    blades together to set the aperture height and centre.
+
+.. note::
+
+   **cora Asset registration intent.** When the ``Slit`` Family
+   graduates from Pending, register this assembly as Asset
+   ``A_station_slits`` with the following structure (mirrors the
+   ``Hexapod_2BM`` / ``Aerotech_ABRS_rotary`` patterns
+   already in ``cora/docs/deployments/2-bm/assets.md``):
+
+   - Family: ``Slit``
+   - Mounted on: front-end stand (floor reference)
+   - controller_id back-reference: ``OMS_VME58_2bma_drive``
+   - Settings (blade motors): ``2bma:m13`` (H+ outboard), ``2bma:m14``
+     (H− inboard), ``2bma:m15`` (V+ up), ``2bma:m16`` (V− down)
+   - Settings (virtual / calc-driven aperture):
+     ``2bma:Slit1Hsize``, ``2bma:Slit1Hcenter``,
+     ``2bma:Slit1Vsize``, ``2bma:Slit1Vcenter``
+   - z position: 25225 mm (from APS reference table)
+   - Per-blade calibration field
+     ``calibration_slope_pix_per_mm`` (one per blade motor),
+     seed values + conditions from the
+     :doc:`../procedures/item_012` field-test table for the
+     "A station — after MRES fix" run (2026-06-14).
+   - Target of Procedure ``calibrate_slit_blade_throw``
+     (:doc:`../procedures/item_012`) and Procedure
+     ``centre_and_close_slits`` (:doc:`../procedures/item_011`).
 
 L3 Filters
 ~~~~~~~~~~
@@ -725,7 +759,15 @@ B-station Slits
    (same standard APS L3-20 four-blade hardware as the front-end
    L3 Slits; reuses the ``Slit`` Family declared there. No filter
    changer is paired with this assembly.)
+:cora Asset: ``B_station_slits`` (proposed name; not yet registered.
+   Used as the ``target_asset_ids`` value by ``calibrate_slit_blade_throw``
+   (:doc:`../procedures/item_012`) and by ``centre_and_close_slits``
+   (:doc:`../procedures/item_011`).)
 :Mounted on: Own stand in 2-BM-B (floor-referenced)
+:Driven by: ``OMS_VME58_2bma_drive`` (same OMS VME58 board as the
+   A-station L3 Slits, despite the B-station mounting location —
+   the IOC crate is in 2-BM-A and addresses both stations'
+   slits over VME)
 :Carries: (beam conditioning only)
 :z position: 50500 mm (read from layout drawing A342-RT1000-02; not
    listed in the APS_1404611 reference table)
@@ -797,6 +839,37 @@ B-station Slits
    (up, screen-labelled ``Slit2V +``) and ``2bma:m10`` for the Y−
    blade (down, screen-labelled ``Slit2V −``). The ``Size`` and
    ``Center`` columns are calc-driven composites.
+
+.. note::
+
+   **cora Asset registration intent.** When the ``Slit`` Family
+   graduates from Pending, register this assembly as Asset
+   ``B_station_slits`` with the same structure as the proposed
+   ``A_station_slits`` Asset (see L3 Slits block above) but
+   with the B-station PV set:
+
+   - Family: ``Slit``
+   - Mounted on: own stand in 2-BM-B (floor reference)
+   - controller_id back-reference: ``OMS_VME58_2bma_drive``
+     (the IOC crate is in 2-BM-A and addresses both stations'
+     slits over VME; both A and B Slit Assets back-reference
+     the same controller)
+   - Settings (blade motors): ``2bma:m11`` and ``2bma:m12`` (H
+     pair, per the label-flip note above), ``2bma:m9`` (V+ up),
+     ``2bma:m10`` (V− down)
+   - Settings (virtual / calc-driven aperture):
+     ``2bma:Slit2Hsize``, ``2bma:Slit2Hcenter``,
+     ``2bma:Slit2Vsize``, ``2bma:Slit2Vcenter``
+   - z position: 50500 mm (read from layout drawing
+     A342-RT1000-02; not in the APS_1404611 reference table)
+   - Per-blade calibration field
+     ``calibration_slope_pix_per_mm`` (one per blade motor),
+     seed values + conditions from the
+     :doc:`../procedures/item_012` field-test table for the
+     "B station (no fix needed)" run (2026-06-14).
+   - Target of Procedure ``calibrate_slit_blade_throw``
+     (:doc:`../procedures/item_012`) and Procedure
+     ``centre_and_close_slits`` (:doc:`../procedures/item_011`).
 
 
 Sample stack

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -211,7 +211,7 @@ A-shutter (front-end)
    **2-BM-A motor controller.** Every ``2bma:mNN`` motor cited in
    the 2-BM-A blocks below (L3 Slits, Y3-30 Mirror, DMM, B-station
    Slits, etc.) is a slot on the OMS-VME58 card in the ``ioc2bma``
-   crate — cora Asset ``OMS_VME58_2bma_drive``. None of those
+   crate — cora Asset ``FrontEndDrive``. None of those
    driven stages are themselves modelled as cora Assets yet (the
    front-end / beam-conditioning band stays in cora's Pending
    list); the controller Asset ships in isolation as the
@@ -227,12 +227,12 @@ L3 Slits
    Family. Standard APS L3-20 four-blade slits — two horizontal
    (X−, X+) and two vertical (Y−, Y+) blade motors, plus per-
    direction derived ``Size`` / ``Center`` calc axes.)
-:cora Asset: ``A_station_slits`` (proposed name; not yet registered.
+:cora Asset: ``ConditioningSlit`` (proposed name; not yet registered.
    Used as the ``target_asset_ids`` value by ``calibrate_slit_blade_throw``
    (:doc:`../procedures/item_012`) and by ``centre_and_close_slits``
    (:doc:`../procedures/item_011`).)
 :Mounted on: Front-end stand (floor-referenced)
-:Driven by: ``OMS_VME58_2bma_drive`` (cora ``MotionController`` Asset
+:Driven by: ``FrontEndDrive`` (cora ``MotionController`` Asset
    already registered in ``cora/docs/deployments/2-bm/assets.md``;
    pending controller_id back-reference from this Asset once it
    registers)
@@ -301,13 +301,13 @@ are available `here <https://anl.box.com/s/sgmoux6db8tsx71pvifzkf2ajopfidqx>`_.
 
    **cora Asset registration intent.** When the ``Slit`` Family
    graduates from Pending, register this assembly as Asset
-   ``A_station_slits`` with the following structure (mirrors the
-   ``Hexapod_2BM`` / ``Aerotech_ABRS_rotary`` patterns
+   ``ConditioningSlit`` with the following structure (mirrors the
+   ``Hexapod`` / ``Rotary`` patterns
    already in ``cora/docs/deployments/2-bm/assets.md``):
 
    - Family: ``Slit``
    - Mounted on: front-end stand (floor reference)
-   - controller_id back-reference: ``OMS_VME58_2bma_drive``
+   - controller_id back-reference: ``FrontEndDrive``
    - Settings (blade motors): ``2bma:m13`` (H+ outboard), ``2bma:m14``
      (H− inboard), ``2bma:m15`` (V+ up), ``2bma:m16`` (V− down)
    - Settings (virtual / calc-driven aperture):
@@ -434,13 +434,14 @@ Y3-30 Mirror
 
 :Role: Vertical-deflecting mirror; defines the alternate beam centrelines
 :Family: Mirror
-   (Pending in cora: Asset ``Y3-30_mirror`` appears in the
-   Pending table at ``docs/deployments/2-bm/assets.md`` (renamed
-   from ``Mirror_2BM`` per cora's #89) and Family ``Mirror`` is
-   listed as "Pending in code" at ``docs/catalog/families.md``.
-   Composes a mirror body with an in-vacuum stripe selector and
-   an external optical-table sub-assembly carrying Y / X / Z
-   stages.)
+   (Pending in cora: Asset ``Mirror`` appears in the Pending
+   table at ``docs/deployments/2-bm/assets.md`` (role-name
+   convention set by cora's #111, after earlier candidate
+   names ``Mirror_2BM`` and ``Y3-30_mirror``); Family
+   ``Mirror`` is listed as "Pending in code" at
+   ``docs/catalog/families.md``. Composes a mirror body with
+   an in-vacuum stripe selector and an external optical-table
+   sub-assembly carrying Y / X / Z stages.)
 :Mounted on: Optical table (``[Dma:table1]`` via the ``table_full`` IOC)
 :Carries: (beam conditioning only)
 :z position: 27626 mm (ref 2: centre of optic; mirror-1 axis)
@@ -776,12 +777,12 @@ B-station Slits
    (same standard APS L3-20 four-blade hardware as the front-end
    L3 Slits; reuses the ``Slit`` Family declared there. No filter
    changer is paired with this assembly.)
-:cora Asset: ``B_station_slits`` (proposed name; not yet registered.
+:cora Asset: ``SampleSlit`` (proposed name; not yet registered.
    Used as the ``target_asset_ids`` value by ``calibrate_slit_blade_throw``
    (:doc:`../procedures/item_012`) and by ``centre_and_close_slits``
    (:doc:`../procedures/item_011`).)
 :Mounted on: Own stand in 2-BM-B (floor-referenced)
-:Driven by: ``OMS_VME58_2bma_drive`` (same OMS VME58 board as the
+:Driven by: ``FrontEndDrive`` (same OMS VME58 board as the
    A-station L3 Slits, despite the B-station mounting location —
    the IOC crate is in 2-BM-A and addresses both stations'
    slits over VME)
@@ -862,13 +863,13 @@ B-station Slits
 
    **cora Asset registration intent.** When the ``Slit`` Family
    graduates from Pending, register this assembly as Asset
-   ``B_station_slits`` with the same structure as the proposed
-   ``A_station_slits`` Asset (see L3 Slits block above) but
+   ``SampleSlit`` with the same structure as the proposed
+   ``ConditioningSlit`` Asset (see L3 Slits block above) but
    with the B-station PV set:
 
    - Family: ``Slit``
    - Mounted on: own stand in 2-BM-B (floor reference)
-   - controller_id back-reference: ``OMS_VME58_2bma_drive``
+   - controller_id back-reference: ``FrontEndDrive``
      (the IOC crate is in 2-BM-A and addresses both stations'
      slits over VME; both A and B Slit Assets back-reference
      the same controller)
@@ -902,24 +903,24 @@ projection space.
 Kinematic chain (bottom to top)::
 
    Sample optical table              (Y only; floor-referenced)
-     +-- Hexapod_2BM                  (6-DOF coarse positioner)
-          +-- Sample_pitch_lam        (laminography pitch, 0-20 deg)
+     +-- Hexapod                  (6-DOF coarse positioner)
+          +-- LaminographyPitch        (laminography pitch, 0-20 deg)
                +-- fixed -10 deg wedge (cancels +10 deg stage hold)
-                    +-- Aerotech_ABRS_rotary  (theta axis)
-                         +-- Sample_top_X     (co-rotates with theta)
-                         +-- Sample_top_Z     (co-rotates with theta)
+                    +-- Rotary  (theta axis)
+                         +-- SampleTop_X     (co-rotates with theta)
+                         +-- SampleTop_Z     (co-rotates with theta)
 
 .. note::
 
    The cora 2-BM asset inventory at
    ``docs/deployments/2-bm/assets.md`` lists four sample-top
-   Devices: ``Sample_top_X``, ``Sample_top_Z``,
+   Devices: ``SampleTop_X``, ``SampleTop_Z``,
    ``Sample_top_Roll``, ``Sample_top_Pitch``.
-   ``Sample_top_X`` and ``Sample_top_Z`` are the Kohzu CYAT-070
+   ``SampleTop_X`` and ``SampleTop_Z`` are the Kohzu CYAT-070
    stages above the rotary and are documented below.
    ``Sample_top_Roll`` and ``Sample_top_Pitch`` correspond to the
    hexapod's Roll (``2bmHXP:m5``) and Pitch (``2bmHXP:m4``) axes —
-   they are part of the **Hexapod_2BM** block below, not separate
+   they are part of the **Hexapod** block below, not separate
    per-component stages above the rotary. cora classifies these
    two as ``PseudoAxis`` Assets ("virtual DoFs over the 2bmHXP
    hexapod-kinematics solver"), confirming the same mapping.
@@ -933,7 +934,7 @@ Kinematic chain (bottom to top)::
    axes ``m100``/``m101``/``m102`` in ``AsynMotor.substitutions``
    (asyn ports ``AeroE1``/``AeroE2``/``AeroE3``). The motor records
    themselves carry generic ``DESC`` strings (``"motor $(N)"``), so
-   the per-Device role (e.g. ``Sample_top_X = 2bmb:m18``) is not
+   the per-Device role (e.g. ``SampleTop_X = 2bmb:m18``) is not
    recoverable from the IOC alone — it is configured in mctoptics
    substitutions, tomoScanStream, ``table.db`` calls, and this
    page. When registering cora Devices against ioc2bmb PVs, treat
@@ -947,7 +948,7 @@ Sample optical table
 :Family: OpticalTable
    (new Family; not yet declared in the cora equipment BC)
 :Mounted on: Hutch floor
-:Carries: Hexapod_2BM (and everything above)
+:Carries: Hexapod (and everything above)
 :Degrees of freedom: 4 motors (Y, downstream X, upstream X, Z). In
    routine operation only Y is moved; the X and Z motors exist but
    are not used for day-to-day sample positioning.
@@ -987,8 +988,8 @@ Sample optical table
    table (Y, DSX, USX, Z), shown for reference when the rarely-used
    X or Z axes need to be touched.
 
-Hexapod_2BM
------------
+Hexapod
+-------
 
 :Role: Coarse 6-DOF sample positioner
 :Family: Hexapod
@@ -998,8 +999,8 @@ Hexapod_2BM
    high-accuracy performance grade) and ``-TAS`` (tested and
    integrated as a system).
 :Mounted on: Sample optical table
-:Carries: Sample_pitch_lam
-:Driven by: ``Aerotech_Hexapod_drive`` (cora ``MotionController``
+:Carries: LaminographyPitch
+:Driven by: ``HexapodDrive`` (cora ``MotionController``
    Asset; specific product line not yet confirmed on this page)
 :Degrees of freedom: X, Y, Z, A (θ\ :sub:`x`), B (θ\ :sub:`y`), C (θ\ :sub:`z`)
 :Travel:
@@ -1053,8 +1054,8 @@ Hexapod_2BM
    struts), the Kohzu SA16A-RM laminography tilt stage (centre), and
    the Aerotech ABS250MP-M-AS air-bearing rotary at top.
 
-Sample_pitch_lam
-----------------
+LaminographyPitch
+-----------------
 
 :Role: Laminography pitch axis
 :Family: LinearStage
@@ -1064,8 +1065,8 @@ Sample_pitch_lam
    ``docs/deployments/2-bm/assets.md``. Consider a dedicated
    ``TiltStage`` Family if more tilt axes appear.)
 :Model: Kohzu SA16A-RM goniometer / tilt stage
-:Mounted on: Hexapod_2BM
-:Carries: Aerotech_ABRS_rotary (via a fixed -10° wedge)
+:Mounted on: Hexapod
+:Carries: Rotary (via a fixed -10° wedge)
 :Travel: 0° to 20° (full mechanical range; see operating convention below)
 :EPICS: ``2bmb:m49``
 :Notes:
@@ -1078,8 +1079,8 @@ Sample_pitch_lam
    laminography setpoint is **+15°** on the stage, i.e. +5° net
    rotary-axis tilt.
 
-Aerotech_ABRS_rotary
---------------------
+Rotary
+------
 
 :Role: Sample rotation axis (theta)
 :Family: RotaryStage
@@ -1087,13 +1088,15 @@ Aerotech_ABRS_rotary
    Stage — Aerotech ABS250MP-M-AS air-bearing direct-drive rotary
    (250 mm aperture, mid-precision class). Drive — Aerotech Ensemble
    HLE10-40-A-MXH (HLe-series digital drive). The cora Device
-   identifier ``Aerotech_ABRS_rotary`` is retained for stability of
-   downstream references even though the installed hardware is the
-   ABS250MP, not an ABRS.
-:Mounted on: Sample_pitch_lam (via a fixed -10° wedge — see above)
-:Carries: Sample_top_X, Sample_top_Z
-:Driven by: ``Aerotech_Ensemble_drive`` (cora ``MotionController``
-   Asset wrapping the Aerotech Ensemble HLE10-40-A-MXH)
+   identifier ``Rotary`` is a role-name per cora's #111 convention
+   (vendor / model lives in the bound Model, not the Asset name).
+   Earlier candidate names: ``Aerotech_ABRS_rotary``,
+   ``aerotech_abs250mp_m_as``.
+:Mounted on: LaminographyPitch (via a fixed -10° wedge — see above)
+:Carries: SampleTop_X, SampleTop_Z
+:Driven by: ``RotaryDrive`` (cora ``MotionController`` Asset
+   wrapping the Aerotech Ensemble HLE10-40-A-MXH; bound Model
+   ``aerotech_ensemble``)
 :Travel: -360 deg to +360 deg
 :Max speed: 720 deg/s
 :Encoder resolution: 0.0001 deg
@@ -1104,12 +1107,12 @@ Aerotech_ABRS_rotary
    <https://github.com/tomography/tomoscan/blob/master/iocBoot/iocTomoScanStream_2BMB/tomoScanStream.substitutions>`__,
    where ``ROTATION = 2bmb:m102``)
 :Notes:
-   The two Sample_top_* stages above this axis (Sample_top_X and
-   Sample_top_Z) co-rotate with theta. In projection geometry their
+   The two Sample_top_* stages above this axis (SampleTop_X and
+   SampleTop_Z) co-rotate with theta. In projection geometry their
    effect is in the rotating frame, not the lab frame.
 
-Sample_top_X
-------------
+SampleTop_X
+-----------
 
 :Role: Fine sample translation perpendicular to the beam
    (co-rotates with theta). Operationally the "0/180 stage" —
@@ -1118,7 +1121,7 @@ Sample_top_X
 :Model: Kohzu CYAT-070 crossed-roller alignment stage,
    80 × 80 mm table, ball-screw lead 1.0 mm. See
    :doc:`../ops/item_050` for the operational page.
-:Mounted on: Aerotech_ABRS_rotary
+:Mounted on: Rotary
 :Carries: (sample)
 :Travel: ±15 mm
 :Resolution: 1 / 0.5 / 0.05 µm (full / half / 1/20 microstep)
@@ -1133,20 +1136,20 @@ Sample_top_X
    (matches ``LENS_SAMPLE_X`` in
    ``iocBoot/iocMCTOptics/mctOptics.substitutions`` — this is the
    sample-side X motor MCTOptics drives for lens/sample alignment.)
-:Driven by: ``OMS_VME58_2bmb_drive`` (cora ``MotionController``
+:Driven by: ``SampleStageDrive`` (cora ``MotionController``
    Asset wrapping the OMS-VME58 card in ``ioc2bmb`` that hosts
    the entire ``2bmb:m1``–``m91`` motor band)
 
-Sample_top_Z
-------------
+SampleTop_Z
+-----------
 
 :Role: Fine sample translation along the beam (co-rotates with
    theta). Operationally the "90/270 stage" — motion lies along
    the beam when theta = 90° or 270°.
 :Family: LinearStage
 :Model: Kohzu CYAT-070 crossed-roller alignment stage
-   (same hardware as Sample_top_X; see :doc:`../ops/item_050`).
-:Mounted on: Aerotech_ABRS_rotary
+   (same hardware as SampleTop_X; see :doc:`../ops/item_050`).
+:Mounted on: Rotary
 :Carries: (sample)
 :Travel: ±15 mm
 :Resolution: 1 / 0.5 / 0.05 µm (full / half / 1/20 microstep)
@@ -1161,8 +1164,8 @@ Sample_top_Z
    (matches ``LENS_SAMPLE_Z`` in
    ``iocBoot/iocMCTOptics/mctOptics.substitutions`` — this is the
    sample-side Z motor MCTOptics drives for lens/sample alignment.)
-:Driven by: ``OMS_VME58_2bmb_drive`` (cora ``MotionController``
-   Asset; same as ``Sample_top_X``)
+:Driven by: ``SampleStageDrive`` (cora ``MotionController``
+   Asset; same as ``SampleTop_X``)
 
 
 Detector system
@@ -1332,8 +1335,8 @@ Macro                        PV                      Purpose
 
 All eight ``2bmb:m1``–``m8`` motors in this map plus ``m17``
 and ``m18`` are slots on the same OMS-VME58 card — cora Asset
-``OMS_VME58_2bmb_drive``. The hexapod motor ``2bmHXP:m3`` is one
-DoF of ``Hexapod_2BM``, driven by ``Aerotech_Hexapod_drive``.
+``SampleStageDrive``. The hexapod motor ``2bmHXP:m3`` is one
+DoF of ``Hexapod``, driven by ``HexapodDrive``.
 
 Calibrated lens positions (mm, both cameras): Pos. 0 = -60.030,
 Pos. 1 = -0.8370, Pos. 2 = 58.64. Camera positions: Pos. 0 = 20,
@@ -1352,8 +1355,8 @@ offsets are held in the IOC's autosave file.
    ``Default`` button restores the per-combination calibrated
    focus / rotation values from the IOC's autosave file.
 
-Optique_Peter_focus_Z
----------------------
+Focus
+-----
 
 (cora Asset identifier; previously called "Optique Peter Z stage"
 in this page.)
@@ -1367,7 +1370,7 @@ in this page.)
    PRO225SL family). cora Model: ``aerotech_pro225sl_1000``.
 :Mounted on: Detector optical table
 :Carries: Optique Peter MICRX080 microscope
-:Driven by: ``Aerotech_2bmbAERO_drive`` (cora ``MotionController``
+:Driven by: ``FocusDrive`` (cora ``MotionController``
    Asset wrapping the Aerotech drive that the ``2bmbAERO`` IOC
    manages)
 :Travel: 1000 mm
@@ -1439,7 +1442,7 @@ rotate axes ``2bmb:table3.X``, ``.Y``, ``.Z``, ``.AX``, ``.AY``,
    Optique Peter Z rail back parallel to the beam after a small
    square X-ray spot is observed to drift across the camera as the
    Z stage translates. This is the procedure that justifies
-   registering an ``OpticalTable`` Family + ``Detector_optical_table``
+   registering an ``OpticalTable`` Family + ``DetectorTable``
    Asset on the cora side.
 
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -736,6 +736,26 @@ B-station Slits
 :EPICS prefix: ``2bma:`` (horizontal motors ``2bma:m11`` and
    ``2bma:m12`` for the X pair; vertical motors ``2bma:m9`` for
    Y+ [up] and ``2bma:m10`` for Y− [down])
+:Virtual motor PVs (composite Size/Centre): the four ``ao``-record
+   PVs below drive both blades of a pair together. Hosted on
+   ``ioc2bmb1.xray.aps.anl.gov:5064`` despite the ``2bma:`` prefix.
+   These are the PVs the ``2slit.adl`` MEDM screen wires to the
+   ``Size`` and ``Center`` text-entry boxes; the ``Size`` /
+   ``Center`` values you set on the screen propagate through
+   downstream calc records to the individual blade motors.
+
+   =========================  ======================  =====================
+   PV                         Role                    Limits (HOPR / LOPR)
+   =========================  ======================  =====================
+   ``2bma:Slit2Hsize``        Horizontal aperture mm  +45.50 / -112.50
+   ``2bma:Slit2Hcenter``      Horizontal centre mm    +37.08 / -41.92
+   ``2bma:Slit2Vsize``        Vertical aperture mm    +115.62 / -34.13
+   ``2bma:Slit2Vcenter``      Vertical centre mm      +52.28 / -22.60
+   =========================  ======================  =====================
+
+   *(Earlier doc attempts referred to* ``2bma:Slit2H:size`` *with a
+   colon — that is NOT the name. The canonical names are no-colon
+   concatenations as listed.)*
 :Notes:
    These are the slits driven by ``b_slit_top`` (= ``2bma:m9``) and
    ``b_slit_bot`` (= ``2bma:m10``) in the energy-change IOC; the

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -45,6 +45,16 @@ Current procedures
   reduction. Operator typically follows with manual rezeroing
   of the four virtual motors to define a new origin. Open
   trigger for a per-station ``Slit`` Asset on the cora side.
+- :doc:`procedures/item_012` —
+  ``calibrate_slit_blade_throw``. Diagnostic procedure that
+  drives each of a station's four blade motors by ``±blade_throw_mm``
+  from baseline, measures the bbox edge shift of the bright spot
+  on the detector, and reports per-blade ``pixels-per-mm`` slopes.
+  Flags same-axis spread and V/H mean-ratio mismatches to
+  identify mis-calibrated blade motors. No deliberate output --
+  all blades restored to baseline. Open trigger to extend the
+  per-station ``Slit`` Asset with per-blade calibration fields
+  on the cora side.
 
 
 Stub procedures (precondition targets of item_002)

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -33,7 +33,7 @@ Current procedures
   defined by the B-station slits, fits the centroid drift, and uses
   the detector optical table (``2bmb:table3.AX`` / ``.AY``) to
   rotate the rail back parallel to the beam. Open trigger for an
-  ``OpticalTable`` Family + ``Detector_optical_table`` Asset on the
+  ``OpticalTable`` Family + ``DetectorTable`` Asset on the
   cora side.
 - :doc:`procedures/item_011` —
   ``centre_and_close_slits``. Drives an L3-style slit

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -35,6 +35,16 @@ Current procedures
   rotate the rail back parallel to the beam. Open trigger for an
   ``OpticalTable`` Family + ``Detector_optical_table`` Asset on the
   cora side.
+- :doc:`procedures/item_011` —
+  ``centre_and_close_slits``. Drives an L3-style slit
+  (``--slit-station A`` or ``B``) so the beam image sits at the
+  centre of the detector frame, then incrementally closes
+  ``Hsize`` / ``Vsize`` to a target (default 0 = fully closed).
+  Two-phase: calibrate + iterate centring on
+  ``Hcenter`` / ``Vcenter`` first, then sequential H / V size
+  reduction. Operator typically follows with manual rezeroing
+  of the four virtual motors to define a new origin. Open
+  trigger for a per-station ``Slit`` Asset on the cora side.
 
 
 Stub procedures (precondition targets of item_002)

--- a/docs/source/procedures/item_001.rst
+++ b/docs/source/procedures/item_001.rst
@@ -51,7 +51,7 @@ from or writes to. The first time a Device appears it should link
 back to :doc:`../manual/item_020` so cora can resolve the wiring.)*
 
 - :doc:`../manual/item_020`: ``<asset_name_1>``
-  (e.g. ``Aerotech_ABRS_rotary``)
+  (e.g. ``Rotary``)
 - :doc:`../manual/item_020`: ``<asset_name_2>``
 
 

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -346,6 +346,14 @@ Parameters
      - (``binmask`` only) Threshold = ``bg_median + N × sigma``
        where ``sigma = 1.4826 × MAD`` (Median Absolute Deviation).
        Default: 5.0.
+   * - ``frames_per_measurement``
+     - int ≥ 1
+     - —
+     - Acquire and average N frames per centroid measurement.
+       Centroid shot-noise drops as ``sqrt(N)`` at N× per-
+       measurement acquisition cost. Default: 1 (no averaging).
+       Try ``4`` for a ~2× SNR boost on the sensitivity matrix
+       without enlarging the calibration step.
 
 
    * - ``camera_pixel_um``

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -628,6 +628,45 @@ wrong (PV name, sign, magnitude), answer ``N`` and the procedure
 exits cleanly via the snapshot restore.
 
 
+Field-test results (v0.0.1, 2026-06-14)
+---------------------------------------
+
+First end-to-end convergent run on 2-BM-B:
+
+:Camera: FLIR Oryx 31MP at ``2bmSP2:`` via MCTOptics
+:Lens: 1.1× (slot 0)
+:Z safety band: 200–500 mm
+:Calibration step: 100 µrad
+:Damping: 0.5
+:Auto-set convergence threshold: 31.4 µrad
+:Sensitivity-matrix condition number: **1.1** (essentially
+   diagonal — AY ↔ slope_X, AX ↔ slope_Y, no cross-coupling)
+
+Convergence trajectory:
+
+==== ============ ============ ============ ===================
+iter ``tilt_X``   ``tilt_Y``   ``|tilt|``   reduction vs prev
+==== ============ ============ ============ ===================
+1    −169 µrad    +397 µrad    431 µrad     —
+2    −85          +203         220          0.51×
+3    −46          +97          107          0.49×
+4    −20          +49          53           0.50×
+5    −10          **+24**      **26**       0.49× ← converged
+==== ============ ============ ============ ===================
+
+Each iteration cut ``|tilt|`` almost exactly in half, matching
+the ``damping=0.5`` prediction to better than 1%. The final
+residual (26 µrad) sits at the PRO225SL rail's intrinsic
+straightness floor (~10–20 µrad over a 300 mm sub-range) — the
+procedure cannot drive ``|tilt|`` below this regardless of
+iteration count. Final table pose:
+``AY = −0.0092 deg``, ``AX = −0.0211 deg``.
+
+Run details and the architectural / bug history that got here
+are in `2bm-procedures CHANGELOG
+<https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__.
+
+
 Notes
 -----
 

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -316,22 +316,36 @@ Parameters
        large corrections; the clip keeps each iteration within
        the linear range near the calibration point. Convergence
        happens over more iterations rather than one big move.
+   * - ``centroid_algorithm``
+     - ``"com"`` | ``"binmask"``
+     - —
+     - Selects the centroid implementation in
+       ``_shared/centroid.py``. Default: ``"com"`` (intensity-
+       weighted centre of mass). Use ``"binmask"`` (background-
+       thresholded geometric centroid) when the bright pixels of
+       the beam lie *outside* the spot envelope (e.g. a saturated
+       stripe far from the geometric centre is biasing COM).
+       Field-tested 2026-06-14 on a 2-BM-B Oryx 31MP frame
+       against an operator hand-eyeballed centre: ``com`` was 8
+       px off, ``binmask`` 30-40 px off (the multilayer halo
+       extends asymmetrically and pulls the binmask centroid
+       off-axis). ``com`` is the right default for this beamline.
+   * - ``threshold_fraction``
+     - 0 < x < 1
+     - —
+     - (``com`` only) Threshold as a fraction of the per-frame
+       maximum pixel value. Default: 0.5.
    * - ``bg_corner_size``
      - int > 4
      - pixels
-     - Per-side length of each of the four corner boxes the
-       centroid algorithm uses to estimate the background-noise
-       level. Default: 100. Reduce only if the beam spot is large
-       enough to spill into a frame corner.
+     - (``binmask`` only) Per-side length of each of four corner
+       boxes used to estimate background statistics. Default: 100.
    * - ``bg_sigma_threshold``
      - > 0
      - σ
-     - Centroid binary-mask threshold is
-       ``bg_median + N × bg_sigma_from_MAD`` (median + Median
-       Absolute Deviation, robust to outliers in the corner
-       samples). Default: 5.0. Smaller N includes more of the
-       dim halo (and more noise); larger N keeps only clearly-
-       above-background pixels.
+     - (``binmask`` only) Threshold = ``bg_median + N × sigma``
+       where ``sigma = 1.4826 × MAD`` (Median Absolute Deviation).
+       Default: 5.0.
 
 
    * - ``camera_pixel_um``

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -316,11 +316,24 @@ Parameters
        large corrections; the clip keeps each iteration within
        the linear range near the calibration point. Convergence
        happens over more iterations rather than one big move.
-   * - ``threshold_fraction``
-     - 0 < x < 1
-     - —
-     - Centroid algorithm threshold as fraction of frame max.
-       Default: 0.5.
+   * - ``bg_corner_size``
+     - int > 4
+     - pixels
+     - Per-side length of each of the four corner boxes the
+       centroid algorithm uses to estimate the background-noise
+       level. Default: 100. Reduce only if the beam spot is large
+       enough to spill into a frame corner.
+   * - ``bg_sigma_threshold``
+     - > 0
+     - σ
+     - Centroid binary-mask threshold is
+       ``bg_median + N × bg_sigma_from_MAD`` (median + Median
+       Absolute Deviation, robust to outliers in the corner
+       samples). Default: 5.0. Smaller N includes more of the
+       dim halo (and more noise); larger N keeps only clearly-
+       above-background pixels.
+
+
    * - ``camera_pixel_um``
      - number > 0
      - µm
@@ -353,6 +366,23 @@ Parameters
      - —
      - Print every planned motion and skip; never moves any
        motor. Camera reads + centroid fits still happen.
+
+
+.. note::
+
+   **Centroid algorithm.** In v0.0.1 the centroid algorithm
+   changed from intensity-weighted COM (``center_of_mass``,
+   fraction-of-max threshold) to a background-thresholded
+   **geometric centroid** (``centroid_above_background``,
+   σ-above-background threshold). Driven by 2-BM-B field testing:
+   the DMM beam has strong horizontal multilayer-stripe modulation
+   that biases an intensity-weighted COM toward whichever stripe
+   happens to be brightest, instead of the geometric centre of the
+   illuminated square aperture. The new algorithm gives every
+   above-threshold pixel an equal vote, so the centroid tracks the
+   geometric centre of the illuminated area regardless of internal
+   structure. Median+MAD on corner samples makes the threshold
+   robust to bright features spilling into a corner.
 
 
 Steps

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -26,7 +26,7 @@ Name
 Devices
 -------
 
-- :doc:`../manual/item_020`: **Optique_Peter_focus_Z** —
+- :doc:`../manual/item_020`: **Focus** —
   ``2bmbAERO:m1`` (Aerotech PRO225SL-1000, 1 m travel).
 - :doc:`../manual/item_020`: **Detector optical table** —
   synApps ``table.db`` composite ``2bmb:table3``; corrective DoFs
@@ -526,7 +526,7 @@ Postconditions
 - ``2bmb:table3.AY`` and ``.AX`` are at the converged values;
   their new positions are logged. (Procedure deliberately does
   not restore these — they're the output.)
-- ``Optique_Peter_focus_Z`` is back at its pre-procedure RBV
+- ``Focus`` is back at its pre-procedure RBV
   (restored from snapshot).
 - All snapshotted camera state is back to its pre-procedure
   values: if the camera was running Continuous on entry, it is
@@ -694,12 +694,12 @@ Notes
   snapshot at exit.
 - This procedure is **not** the same as cora's stubbed
   ``resolution_alignment`` (which targets the same
-  ``Optique_Peter_focus_Z`` Asset but optimises **lens focus**
+  ``Focus`` Asset but optimises **lens focus**
   on a fixed sample, not the rail-to-beam angular alignment).
   Both procedures share Assets but operate on different
   physical surfaces.
 - Open trigger this procedure creates: register a
-  ``Detector_optical_table`` Asset (Family ``OpticalTable``) in
+  ``DetectorTable`` Asset (Family ``OpticalTable``) in
   ``cora/docs/deployments/2-bm/assets.md``, then add a
   ``detector_z_rail_alignment`` entry to that deployment's
   ``procedures.md`` referencing this page.

--- a/docs/source/procedures/item_009.rst
+++ b/docs/source/procedures/item_009.rst
@@ -21,7 +21,7 @@ Devices
 
 - :doc:`../manual/item_020`: **Sample stack** — the relevant lateral
   axis depends on the sample mount. Typically one of
-  ``Sample_top_X`` (``2bmb:m18``), ``Sample_top_Z`` (``2bmb:m17``),
+  ``SampleTop_X`` (``2bmb:m18``), ``SampleTop_Z`` (``2bmb:m17``),
   the hexapod X/Y axes (``2bmHXP:m1 / m2``), or the sample optical
   table Y (``2bmb:m24``).
 

--- a/docs/source/procedures/item_011.rst
+++ b/docs/source/procedures/item_011.rst
@@ -2,14 +2,14 @@
 Centre and close an L3-style slit aperture
 ============================================
 
-Drive an L3-style slit's virtual-motor ``Hcenter`` and ``Vcenter``
-to bring the beam image to the centre of the detector frame, then
-incrementally close the ``Hsize`` and ``Vsize`` apertures to a
-target size (typically 0 = fully closed). The operator typically
-follows this with a manual rezeroing step (``caput`` Hcenter /
-Vcenter / Hsize / Vsize to 0) to define a new origin for the
-slit virtual motors -- that rezeroing is **not** part of this
-procedure in v0.0.1.
+Three-phase L3-style slit procedure: (1) drive the virtual-motor
+``Hcenter`` / ``Vcenter`` so the beam image lands at the centre
+of the detector frame; (2) incrementally close ``Hsize`` /
+``Vsize`` to a target size (typically 0 = fully closed); (3)
+**rezero** the virtual motors -- redefine the current physical
+pose as the new origin so the four virtual motors read 0 at the
+closed + centred position. Phase 3 is **default-enabled** but
+gated per axis; ``--no-rezero`` skips it.
 
 The procedure is parameterised over which slit station to target:
 ``A`` (front-end L3 Slits at z = 25225 mm) or ``B`` (2-BM-B
@@ -141,6 +141,17 @@ Parameters
      - ≥ 0
      - mm
      - Final V aperture. Default: 0.
+   * - ``rezero``
+     - bool
+     - —
+     - If True (default), after closing the procedure rezeros the
+       four virtual motors by setting the per-axis ``<axis>set``
+       PV to ``Set``, writing 0 to ``<axis>center`` /
+       ``<axis>size``, and switching ``<axis>set`` back to
+       ``Use``. Each H and V rezero is gated separately and
+       irreversible. Set to False (CLI flag ``--no-rezero``) to
+       skip and leave the slit virtual motors in their absolute
+       coordinate system.
    * - ``exposure_time``
      - > 0
      - s
@@ -234,14 +245,44 @@ Steps
        ``move_table_axis <slit>Vsize <new>``;
        ``acquire_image`` + centroid each step.
    * - 6
-     - **Restore.** Run by ``try / finally`` on every exit path.
-       On **clean completion** (centred + closed): slits are
-       left at the new (centred, closed) state. On **any other
-       exit** (OperatorAbort, exception, divergence): slits go
-       back to the snapshot baseline. Camera state always
-       restored.
+     - **Phase 3 (default ON): Rezero.** For each axis (H, V),
+       separately gated:
 
-       Slit restore order: Hcenter → Vcenter → Hsize → Vsize.
+       (a) ``caput <slit>{H,V}set "Set"`` -- switches the slit
+       calc records into position-redefinition mode.
+
+       (b) ``caput <slit>{H,V}center 0`` and
+       ``caput <slit>{H,V}size 0`` -- in Set mode these writes
+       redefine the current physical pose as the new origin
+       rather than commanding motion.
+
+       (c) ``caput <slit>{H,V}set "Use"`` -- restores motion
+       semantics for subsequent moves.
+
+       **IRREVERSIBLE.** Once any rezero write is issued, the
+       snapshot-restore for slits is disabled: the pre-rezero
+       baseline values are in the old coordinate system, and
+       writing them back through the new origin would
+       physically move the slits to arbitrary positions.
+       Operator can answer ``N`` at the H gate to skip
+       rezeroing entirely (keeps the centred + closed state);
+       answering ``N`` at the V gate after the H rezero
+       succeeded leaves H rezeroed and V untouched.
+
+       Skip the entire phase via the ``--no-rezero`` flag.
+     - 4 ``caput`` per axis: ``<slit>Hset``, ``<slit>Hcenter``,
+       ``<slit>Hsize``, ``<slit>Hset`` for H; same for V.
+   * - 7
+     - **Restore.** Run by ``try / finally`` on every exit path.
+       Slits are restored to baseline **unless** either:
+
+       - Procedure completed centring + closing cleanly (slits
+         are the deliberate output), OR
+       - Any rezero write was issued (snapshot is meaningless
+         in the new coordinate system).
+
+       Camera state always restored. Slit restore order:
+       Hcenter → Vcenter → Hsize → Vsize.
      - ``_Snapshot.restore(restore_slits=…)`` → four
        ``move_table_axis`` calls then the camera-state caputs.
 
@@ -258,10 +299,12 @@ On **clean completion**:
   (typically both 0) **or** the beam was no longer above
   threshold at a size slightly above target.
 - Camera state restored to the operator's pre-procedure values.
-- The new slit centre + closed size remain as the procedure's
-  deliberate output. Operator follows up by manually rezeroing
-  the four virtual motors to define a new origin (not
-  automated in v0.0.1).
+- The slit virtual motors are left at the centred + closed
+  state. If ``--rezero`` was kept on (default), all four virtual
+  motors read **0** at the current physical pose (new origin
+  defined). If ``--no-rezero`` was passed, the virtual motors
+  read the absolute pre-rezero values (closed + centred in the
+  old coordinate system).
 
 On **abort**:
 
@@ -350,7 +393,7 @@ Notes
   records which in turn drive the underlying blade motors. The
   procedure uses ``move_table_axis`` for motion-done because the
   pattern is the same as the detector optical table: write the
-  soft PV, poll the underlying motor ``.DMOV``s.
+  soft PV, poll the underlying motors' ``.DMOV``.
 - Open trigger this procedure creates: register a per-station
   ``Slit`` Asset on the cora side and a ``centre_and_close_slits``
   Procedure record in

--- a/docs/source/procedures/item_011.rst
+++ b/docs/source/procedures/item_011.rst
@@ -118,7 +118,18 @@ Parameters
      - > 0
      - pixels
      - Centroid must be within N pixels of the frame centre in
-       both axes to declare centring converged. Default: 5.
+       both axes to declare centring converged. Default: 15
+       (at the COM noise floor on 2-BM-B's multilayer-stripe
+       images; tightening below ~15 pix requires frame averaging
+       via ``--frames-per-measurement``).
+   * - ``centring_divergence_grow_threshold``
+     - > 1
+     - ×
+     - Abort centring if ``|err|`` grows by more than this
+       factor between iterations. Default: 2.0 (looser than
+       :doc:`item_002`'s 1.5× because COM noise on slit-edge
+       images can briefly bump ``|err|`` at small corrections
+       without indicating a real failure).
    * - ``centring_max_iterations``
      - ≥ 1
      - —

--- a/docs/source/procedures/item_011.rst
+++ b/docs/source/procedures/item_011.rst
@@ -1,0 +1,357 @@
+============================================
+Centre and close an L3-style slit aperture
+============================================
+
+Drive an L3-style slit's virtual-motor ``Hcenter`` and ``Vcenter``
+to bring the beam image to the centre of the detector frame, then
+incrementally close the ``Hsize`` and ``Vsize`` apertures to a
+target size (typically 0 = fully closed). The operator typically
+follows this with a manual rezeroing step (``caput`` Hcenter /
+Vcenter / Hsize / Vsize to 0) to define a new origin for the
+slit virtual motors -- that rezeroing is **not** part of this
+procedure in v0.0.1.
+
+The procedure is parameterised over which slit station to target:
+``A`` (front-end L3 Slits at z = 25225 mm) or ``B`` (2-BM-B
+entrance L3-style slits at z = 50500 mm, default). The four
+virtual-motor PVs for each station follow the same template
+``<PREFIX>Hcenter``, ``<PREFIX>Vcenter``, ``<PREFIX>Hsize``,
+``<PREFIX>Vsize``; see :doc:`../manual/item_020` for the per-
+station prefix.
+
+
+Name
+----
+
+``centre_and_close_slits``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **A-station L3 Slits** OR
+  **B-station L3-style Slits** -- selected via the
+  ``--slit-station`` flag. The procedure drives the four ``ao``
+  virtual-motor PVs (``Hsize``, ``Hcenter``, ``Vsize``,
+  ``Vcenter``) and polls the four underlying blade motors'
+  ``.DMOV`` to detect motion completion.
+- :doc:`../manual/item_020`: **MCTOptics** -- read only. Camera +
+  lens are auto-detected from
+  ``2bm:MCTOptics:CameraSelect / LensSelect`` as in
+  :doc:`item_002`.
+- :doc:`../manual/item_020`: **Detector microscope** (whichever
+  Camera/Lens is currently selected) -- used to image the beam
+  spot for centroid measurement.
+
+
+Preconditions
+-------------
+
+Same upstream preconditions as :doc:`item_002`
+(see its Preconditions table for the full machine-readable list,
+including PSS hutches secure, ACIS permit, FES + B-shutter open,
+energy configured, sample out of beam). The procedure-specific
+preconditions:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 48 30
+
+   * - State
+     - Predicate
+     - Satisfied by
+   * - ``slit_initially_open``
+     - The chosen slit has Hsize > 0 and Vsize > 0 (i.e. some
+       beam reaches the detector). Procedure aborts at calibration
+       if no centroid signal.
+     - operator (slit must be open enough to see a beam spot)
+   * - ``beam_visible_at_detector``
+     - The current camera+lens combination produces a centroid
+       above threshold for the current beam state. Tested
+       implicitly: calibration's baseline centroid measurement
+       fails with the upstream-precondition checklist if no signal.
+     - cascade of all upstream preconditions for :doc:`item_002`
+
+
+Operating envelope (v0.0.1)
+---------------------------
+
+- **Per-motion confirmation gate** on every slit move (centring
+  perturb / restore / iteration correction, every closing step).
+- **Snapshot + restore** for slit Hcenter, Vcenter, Hsize, Vsize
+  plus camera state. On clean completion the new (centred,
+  closed) state is kept; on abort the procedure restores
+  everything to baseline.
+- **Centring divergence guard**: aborts if centroid error magnitude
+  grows by >1.5× between consecutive iterations.
+- **Centring sensitivity sanity floor**: if the 2x2 matrix M has
+  ``|det| < min`` (default 1.0 pix²/mm²), the procedure aborts
+  with a clear "calibration step too small" message. Operator
+  remedy: ``--centring-step-mm 1.0`` or larger.
+
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 12 52
+
+   * - Name
+     - Type
+     - Unit
+     - Description
+   * - ``slit_station``
+     - ``"A"`` or ``"B"``
+     - —
+     - Which station's slits to drive. Default: ``B``.
+   * - ``centring_step_mm``
+     - > 0
+     - mm
+     - Perturbation applied to Hcenter / Vcenter during
+       sensitivity calibration. Default: 0.5.
+   * - ``centring_threshold_pix``
+     - > 0
+     - pixels
+     - Centroid must be within N pixels of the frame centre in
+       both axes to declare centring converged. Default: 5.
+   * - ``centring_max_iterations``
+     - ≥ 1
+     - —
+     - Default: 5.
+   * - ``centring_damping``
+     - 0 < d ≤ 1
+     - —
+     - Per-iteration correction multiplier. Default: 0.5.
+   * - ``centring_max_correction_mm``
+     - > 0
+     - mm
+     - Clip on per-iteration ``|dHcenter|`` / ``|dVcenter|``.
+       Default: 1.0.
+   * - ``closing_step_mm``
+     - > 0
+     - mm
+     - Size reduction per closing step (H and V alternating).
+       Default: 0.1.
+   * - ``target_h_size_mm``
+     - ≥ 0
+     - mm
+     - Final H aperture. Default: 0 (fully closed).
+   * - ``target_v_size_mm``
+     - ≥ 0
+     - mm
+     - Final V aperture. Default: 0.
+   * - ``exposure_time``
+     - > 0
+     - s
+     - Camera exposure. Default: 0.2.
+
+(Common parameters with :doc:`item_002` — ``centroid_algorithm``,
+``threshold_fraction``, ``bg_corner_size``, ``bg_sigma_threshold``,
+``frames_per_measurement``, ``camera_pixel_um``, ``--yes``,
+``--confirm-restore``, ``--dry-run``, ``--log-level`` — are
+documented there.)
+
+
+Steps
+-----
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 32 63
+
+   * - #
+     - Action
+     - PV / call
+   * - 1
+     - **Detect operator-set configuration.** Read MCTOptics
+       CameraSelect / LensSelect; derive ``cam_prefix`` +
+       magnification; read camera binning and frame dimensions
+       (``cam1:SizeX_RBV`` / ``SizeY_RBV``); compute frame centre
+       in pixel coordinates as the centring target.
+     - ``caget 2bm:MCTOptics:CameraSelect / LensSelect``;
+       ``caget <cam>cam1:BinX_RBV / SizeX_RBV / SizeY_RBV``
+   * - 2
+     - **Snapshot pre-procedure state**: slit Hcenter, Vcenter,
+       Hsize, Vsize, full camera state.
+     - ``caget <slit>Hcenter / Vcenter / Hsize / Vsize``;
+       ``caget <cam>cam1:{Acquire, AcquireTime, NumImages,
+       ImageMode, TriggerMode, TriggerSource, TriggerOverlap,
+       ExposureMode, ArrayCallbacks}``.
+   * - 3
+     - **Calibrate centring sensitivity matrix M (2×2)**:
+
+       (a) Measure baseline centroid (cx0, cy0).
+
+       (b) **[gated]** Perturb ``Hcenter`` by
+       ``+centring_step_mm``; re-measure; restore. Compute
+       ``M_Hc_x = (cx_new − cx0) / Δ`` and likewise for
+       ``M_Hc_y``.
+
+       (c) **[gated]** Same for ``Vcenter`` to get ``M_Vc_x``,
+       ``M_Vc_y``.
+
+       (d) Sanity-check: ``|det(M)|`` ≥
+       ``centring_min_sensitivity``. Below floor: abort with
+       "increase ``--centring-step-mm``".
+
+       Logs SVD singular values and condition number; warns when
+       ``cond > 10``.
+     - ``move_table_axis <slit>Hcenter <Δ>``; ``move_table_axis
+       <slit>Vcenter <Δ>``; ``acquire_image``; centroid
+       (``com`` or ``binmask``).
+   * - 4
+     - **Iterate centring**: for ``i = 1 … max_iterations``:
+
+       (a) Measure centroid; compute error = centroid − frame_centre.
+
+       (b) If both ``|error_x|`` and ``|error_y|`` below
+       ``centring_threshold_pix``, **break (converged)**.
+
+       (c) Divergence guard: abort if ``|error|`` grew by >1.5×
+       vs previous iter.
+
+       (d) **[gated]** Compute correction
+       ``(dHc, dVc) = M_inv @ (−error)``, multiply by
+       ``centring_damping``, clip each axis to
+       ``±centring_max_correction_mm``. Apply both Hcenter and
+       Vcenter in a single confirmation gate.
+     - ``move_table_axis <slit>Hcenter <new>``;
+       ``move_table_axis <slit>Vcenter <new>``.
+   * - 5
+     - **Close slits**: alternating H / V size reduction in
+       ``closing_step_mm`` increments. Each step is **[gated]**;
+       a centroid measurement after each step verifies the beam
+       is still visible. Loop terminates when:
+
+       - Both ``Hsize == target_h_size_mm`` and
+         ``Vsize == target_v_size_mm`` (clean completion), OR
+       - The centroid algorithm returns ``None`` (beam no longer
+         above threshold — expected when slits close past the
+         beam envelope). Procedure logs the H / V at which the
+         beam disappeared and exits successfully.
+     - ``move_table_axis <slit>Hsize <new>``;
+       ``move_table_axis <slit>Vsize <new>``;
+       ``acquire_image`` + centroid each step.
+   * - 6
+     - **Restore.** Run by ``try / finally`` on every exit path.
+       On **clean completion** (centred + closed): slits are
+       left at the new (centred, closed) state. On **any other
+       exit** (OperatorAbort, exception, divergence): slits go
+       back to the snapshot baseline. Camera state always
+       restored.
+
+       Slit restore order: Hcenter → Vcenter → Hsize → Vsize.
+     - ``_Snapshot.restore(restore_slits=…)`` → four
+       ``move_table_axis`` calls then the camera-state caputs.
+
+
+Postconditions
+--------------
+
+On **clean completion**:
+
+- Centroid is within ``centring_threshold_pix`` of the frame
+  centre in both axes (at the time of the final centring
+  measurement).
+- ``Hsize == target_h_size_mm`` and ``Vsize == target_v_size_mm``
+  (typically both 0) **or** the beam was no longer above
+  threshold at a size slightly above target.
+- Camera state restored to the operator's pre-procedure values.
+- The new slit centre + closed size remain as the procedure's
+  deliberate output. Operator follows up by manually rezeroing
+  the four virtual motors to define a new origin (not
+  automated in v0.0.1).
+
+On **abort**:
+
+- All four slit virtual motors restored to snapshot baseline.
+- Camera state restored.
+
+
+Failure modes
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Symptom
+     - Recovery
+   * - ``OperatorAbort`` at any gate.
+     - ``try / finally`` runs restore: slits back to baseline,
+       camera back to snapshot. Re-launch when ready.
+   * - Calibration baseline centroid fails ("no signal above
+       threshold").
+     - One of the upstream preconditions failed -- the error
+       message prints a checklist. Open FES + B-shutter, verify
+       beam, slits open wide enough, etc.
+   * - Sensitivity matrix near-singular.
+     - The slit-centre perturbation produced negligible
+       centroid motion. Try larger ``--centring-step-mm``
+       (start with 1.0 mm; up to several mm for very-distant
+       slit / detector geometries).
+   * - Centring diverges (error grows >1.5× iter-to-iter).
+     - The sensitivity matrix M has a sign or magnitude error.
+       Re-run calibration with a larger ``--centring-step-mm``.
+   * - Centring runs out of iterations without converging.
+     - Restore puts slits back to baseline. Increase
+       ``--centring-max-iterations`` or relax
+       ``--centring-threshold-pix``.
+   * - Closing step makes the beam disappear earlier than
+       expected (e.g. at H = 0.3 mm rather than 0.1).
+     - Not a failure -- the procedure logs the H/V at which the
+       beam disappeared and exits successfully. The "closed
+       past beam" criterion is intentional: it confirms the
+       slits actually cut off the beam.
+
+
+Operator walkthrough
+--------------------
+
+- Confirm upstream preconditions (FES, B-shutter, beam, sample
+  out of beam, detector visible on MEDM).
+- Launch with default flags; ``--slit-station B`` is the
+  default.
+- The first ~4 prompts confirm centring-sensitivity calibration
+  motions (perturb Hc, restore, perturb Vc, restore). Each is a
+  small move (default 0.5 mm) and should produce a visible
+  centroid shift on the live view.
+- After M is logged with a reasonable condition number (< 10),
+  iteration begins. Each iter prompts once for the (Hcenter,
+  Vcenter) pair correction. Centroid should drop toward the
+  frame centre.
+- Once centred (within ``centring_threshold_pix``), the closing
+  phase starts. Each step is a 0.1 mm reduction; the operator
+  sees the spot shrink on the live view.
+- Procedure exits when both sizes reach 0 or the beam
+  disappears.
+
+The y/N gate at the terminal is the operator's safety check --
+read the plan block before answering ``y``. If anything looks
+wrong (PV name, sign, magnitude), answer ``N`` and the
+procedure restores cleanly.
+
+
+Notes
+-----
+
+- The 8.6 µrad-scale precision of :doc:`item_002` is not the
+  goal here: this procedure positions the slits in millimetres,
+  not the rail in microradians. ``centring_threshold_pix = 5``
+  with bin 2×2 at 1.1× means the centroid is within 5 × 6.27 /
+  1.1 ≈ 28 µm object-side -- fine for slit centring.
+- The closing phase is intentionally **sequential** (H step,
+  measure, V step, measure, ...) rather than simultaneous: each
+  step gives the operator a fresh image to confirm the beam is
+  shrinking as expected, and the centroid measurement detects
+  the "beam disappeared" condition that ends the loop.
+- The slit virtual motors (``ao`` records) drive downstream calc
+  records which in turn drive the underlying blade motors. The
+  procedure uses ``move_table_axis`` for motion-done because the
+  pattern is the same as the detector optical table: write the
+  soft PV, poll the underlying motor ``.DMOV``s.
+- Open trigger this procedure creates: register a per-station
+  ``Slit`` Asset on the cora side and a ``centre_and_close_slits``
+  Procedure record in
+  ``cora/docs/deployments/2-bm/procedures.md``.

--- a/docs/source/procedures/item_011.rst
+++ b/docs/source/procedures/item_011.rst
@@ -2,14 +2,18 @@
 Centre and close an L3-style slit aperture
 ============================================
 
-Three-phase L3-style slit procedure: (1) drive the virtual-motor
+Four-phase L3-style slit procedure: (1) drive the virtual-motor
 ``Hcenter`` / ``Vcenter`` so the beam image lands at the centre
 of the detector frame; (2) incrementally close ``Hsize`` /
 ``Vsize`` to a target size (typically 0 = fully closed); (3)
 **rezero** the virtual motors -- redefine the current physical
 pose as the new origin so the four virtual motors read 0 at the
-closed + centred position. Phase 3 is **default-enabled** but
-gated per axis; ``--no-rezero`` skips it.
+closed + centred position; (4) **reopen** the slits to the
+original aperture (snapshot's ``Hsize`` / ``Vsize``, e.g. 1 mm)
+so the operator ends with a usable beam through a centred slit.
+
+Phases 3 and 4 are both **default-enabled** but gated per axis;
+``--no-rezero`` / ``--no-reopen`` skip the respective phase.
 
 The procedure is parameterised over which slit station to target:
 ``A`` (front-end L3 Slits at z = 25225 mm) or ``B`` (2-BM-B
@@ -152,6 +156,16 @@ Parameters
        irreversible. Set to False (CLI flag ``--no-rezero``) to
        skip and leave the slit virtual motors in their absolute
        coordinate system.
+   * - ``reopen``
+     - bool
+     - —
+     - If True (default), after rezero (or after closing, if
+       rezero is disabled) the procedure caputs the snapshot's
+       original ``Hsize`` / ``Vsize`` back into the slit
+       virtual motors. Each axis gated. Operator ends with the
+       slits open at the original aperture centred on the
+       (possibly new) origin -- ready for use. CLI flag
+       ``--no-reopen`` to skip (leaves slits closed).
    * - ``exposure_time``
      - > 0
      - s
@@ -273,6 +287,20 @@ Steps
      - 4 ``caput`` per axis: ``<slit>Hset``, ``<slit>Hcenter``,
        ``<slit>Hsize``, ``<slit>Hset`` for H; same for V.
    * - 7
+     - **Phase 4 (default ON): Reopen.** Per axis, gated:
+       caput the snapshot's original ``Hsize`` (resp. ``Vsize``)
+       back into the virtual motor. If phase 3 (rezero) ran,
+       this is interpreted in the new coordinate system -- the
+       slits open by the original aperture (e.g. 1 mm) centred
+       on the new origin (= beam axis). If rezero was skipped,
+       the aperture size write still works as an absolute size;
+       only the coordinate-system label is unchanged.
+
+       Skip with the ``--no-reopen`` flag (operator can leave
+       the slits closed for inspection).
+     - ``move_table_axis <slit>Hsize <snapshot.Hsize>``;
+       ``move_table_axis <slit>Vsize <snapshot.Vsize>``.
+   * - 8
      - **Restore.** Run by ``try / finally`` on every exit path.
        Slits are restored to baseline **unless** either:
 
@@ -299,12 +327,20 @@ On **clean completion**:
   (typically both 0) **or** the beam was no longer above
   threshold at a size slightly above target.
 - Camera state restored to the operator's pre-procedure values.
-- The slit virtual motors are left at the centred + closed
-  state. If ``--rezero`` was kept on (default), all four virtual
-  motors read **0** at the current physical pose (new origin
-  defined). If ``--no-rezero`` was passed, the virtual motors
-  read the absolute pre-rezero values (closed + centred in the
-  old coordinate system).
+- The slit virtual motors' final state depends on which phases
+  ran:
+
+  - **Default (rezero + reopen both on)**: virtual motors read
+    ``Hcenter = Vcenter = 0`` and ``Hsize = Vsize = original
+    aperture`` (e.g. 1 mm). New origin is defined; slits are
+    open at the original aperture centred on the beam axis.
+  - **``--no-reopen``**: virtual motors read ``Hsize = Vsize = 0``
+    (slits closed). Origin set if rezero ran.
+  - **``--no-rezero`` (+ default reopen)**: slits open at the
+    original aperture, centred on the corrected pose;
+    coordinate system unchanged from pre-procedure.
+  - **``--no-rezero --no-reopen``**: slits closed at the new
+    centred pose, no coordinate change. Useful for verification.
 
 On **abort**:
 

--- a/docs/source/procedures/item_012.rst
+++ b/docs/source/procedures/item_012.rst
@@ -1,0 +1,346 @@
+================================================
+Calibrate the throw of each L3 slit blade motor
+================================================
+
+Diagnostic procedure: for each of the four blade motors in a chosen
+L3-style slit station, drive the motor by a known mechanical throw
+(``± blade_throw_mm`` from baseline), measure how far the
+corresponding bright-spot edge moves on the detector, and report
+the resulting **pixels-per-mm** slope.
+
+The two H-axis blades should agree on ``|slope|``; the two V-axis
+blades should agree on ``|slope|``; H and V means should also agree
+to within a few percent when both axes share the same underlying
+encoder calibration. A spread between same-axis blades points at
+one specific motor record; an H-vs-V mismatch points at the whole
+axis pair.
+
+This procedure produces **no deliberate output** -- every blade is
+restored to its baseline position after measurement. Intended as a
+diagnostic to run when :doc:`item_011` produces an asymmetric image
+(e.g. a 1×1 mm aperture rendering as a noticeably non-square
+rectangle on the detector), to identify which blade(s) need their
+``.MRES`` / encoder direction corrected in the motor IOC.
+
+
+Name
+----
+
+``calibrate_slit_blade_throw``
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **A-station L3 Slits** OR **B-station
+  L3-style Slits** -- selected via the ``--slit-station`` flag.
+  The procedure drives the four underlying blade motor records
+  directly (e.g. ``2bma:m9.VAL``), **not** the virtual ``Slit*Hsize``
+  /``*Hcenter`` etc. ao records -- the slope it measures is the
+  raw motor-mm calibration, independent of the slit calc.
+- :doc:`../manual/item_020`: **MCTOptics** -- read only. Camera +
+  lens are auto-detected from
+  ``2bm:MCTOptics:CameraSelect / LensSelect`` as in
+  :doc:`item_002`.
+- :doc:`../manual/item_020`: **Detector microscope** (whichever
+  Camera/Lens is currently selected) -- used to image the beam
+  spot whose bounding-box edges are tracked.
+
+
+Preconditions
+-------------
+
+Same upstream preconditions as :doc:`item_002` (FES + B-shutter
+open, ACIS permit, hutch secure, energy configured, sample out
+of beam, detector visible). The procedure-specific preconditions:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 48 30
+
+   * - State
+     - Predicate
+     - Satisfied by
+   * - ``slit_aperture_open``
+     - The chosen slit has Hsize > 0 and Vsize > 0 large enough
+       that the spot survives a ``+ blade_throw_mm`` move on
+       every blade. With default ``blade_throw_mm = 0.5``, an
+       initial aperture of ≥ 1 mm × 1 mm is recommended.
+     - typically the operator runs :doc:`item_011` immediately
+       beforehand, then opens to 1 mm before calibrating.
+   * - ``spot_visible_at_detector``
+     - The current camera + lens combination produces a bright
+       spot above the background-MAD threshold. Procedure aborts
+       at the initial COM measurement otherwise.
+     - cascade of all upstream preconditions for :doc:`item_002`.
+
+
+Operating envelope (v0.0.1)
+---------------------------
+
+- **Per-motion confirmation gate** on every blade move (``+throw``,
+  ``-throw``, restore-to-baseline -- 3 gated motions per blade,
+  12 total for a 4-blade station).
+- **Snapshot + restore** for all four blade baseline positions
+  plus camera state. The blade-restore order in the snapshot is
+  the order the blade motors are listed in ``SLIT_STATIONS``;
+  camera follows.
+- **Always restores**, regardless of completion -- this is a
+  measurement, not a state-change procedure.
+- **Centroid-ROI gating**: bbox edges are detected within a
+  ``±edge_roi_half_size_pix`` window around the initial spot
+  centroid. The ROI must be large enough to contain the spot at
+  ``+ blade_throw_mm`` (where one edge has shifted **outward**
+  from baseline). Default 400 pix covers a ~500-px spot with
+  ~200 pix shift on each side.
+- **Threshold from background MAD**: bbox threshold =
+  ``bg_median + N · σ``, with ``σ`` from the median absolute
+  deviation of four ROI-corner background patches (corner size
+  ``--bg-corner-size``, default 80 pix). Default
+  ``N = bg_sigma_threshold = 5.0``.
+
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 12 52
+
+   * - Name
+     - Type
+     - Unit
+     - Description
+   * - ``slit_station``
+     - ``"A"`` or ``"B"``
+     - —
+     - Which station's blades to calibrate. Default: ``B``.
+   * - ``blade_throw_mm``
+     - > 0
+     - mm
+     - Each blade is driven from ``baseline + this`` to
+       ``baseline − this`` (full motor throw is ``2 × this``).
+       Default: 0.5 mm.
+   * - ``edge_roi_half_size_pix``
+     - > 0
+     - pix
+     - Half-side of the ROI around the initial spot centroid
+       used for bbox edge detection. Must contain the entire
+       spot at ``+blade_throw_mm`` (one edge has moved further
+       outward than baseline). Default: 400.
+   * - ``bg_corner_size``
+     - > 0
+     - pix
+     - Per-side length of the four ROI-corner patches used to
+       estimate background ``median`` + ``MAD``. Default: 80.
+   * - ``bg_sigma_threshold``
+     - > 0
+     - —
+     - Bbox threshold = ``bg_median + N · σ`` with ``σ`` from
+       ``1.4826 · MAD``. Default: 5.0.
+   * - ``threshold_fraction``
+     - 0 < f < 1
+     - —
+     - Used by the **initial** intensity-weighted COM that sets
+       the ROI centre. Same definition as :doc:`item_011`.
+       Default: 0.5.
+   * - ``frames_per_measurement``
+     - ≥ 1
+     - —
+     - Acquire and average N frames per bbox measurement. With
+       multilayer-stripe images, ``N ≥ 4`` notably reduces
+       per-edge jitter. Default: 1.
+   * - ``exposure_time``
+     - > 0
+     - s
+     - Camera exposure. Default: 0.2.
+
+(Common parameters with :doc:`item_002` and :doc:`item_011` —
+``camera_pixel_um``, ``--yes``, ``--confirm-restore``,
+``--no-cora-log``, ``--dry-run``, ``--log-level`` — are
+documented in their respective pages.)
+
+
+Steps
+-----
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 32 63
+
+   * - #
+     - Action
+     - PV / call
+   * - 1
+     - **Detect operator-set configuration.** Read MCTOptics
+       CameraSelect / LensSelect; derive ``cam_prefix`` +
+       magnification; read camera binning and frame dimensions.
+     - ``caget 2bm:MCTOptics:CameraSelect / LensSelect``;
+       ``caget <cam>cam1:BinX_RBV / SizeX_RBV / SizeY_RBV``.
+   * - 2
+     - **Snapshot pre-procedure state**: each blade motor's
+       ``.RBV`` and full camera state.
+     - ``caget <blade>.RBV`` for the 4 blades;
+       ``caget <cam>cam1:{Acquire, AcquireTime, NumImages,
+       ImageMode, TriggerMode, TriggerSource, TriggerOverlap,
+       ExposureMode, ArrayCallbacks}``.
+   * - 3
+     - **Measure baseline spot centroid** (intensity-weighted
+       COM at ``threshold_fraction`` of the frame max). Stores
+       ``(cx, cy)`` as the ROI centre used by all subsequent
+       bbox measurements.
+     - ``acquire_image`` × ``frames_per_measurement``; COM via
+       ``center_of_mass``.
+   * - 4
+     - **For each blade motor** (4 iterations):
+
+       (a) **[gated]** Move blade by ``+ blade_throw_mm`` from
+       baseline.
+
+       (b) Acquire image, measure bbox within ROI
+       (``±edge_roi_half_size_pix`` around baseline centroid):
+       background ``median + MAD`` over the four ROI corners;
+       threshold = ``bg_median + bg_sigma_threshold · σ``; bbox =
+       min/max of the above-threshold mask in y and x.
+
+       (c) **[gated]** Move blade by ``− blade_throw_mm`` from
+       baseline (full motor throw = ``2 × blade_throw_mm``).
+
+       (d) Acquire image, measure bbox again.
+
+       (e) **[gated]** Restore blade to baseline.
+
+       (f) Compute edge changes: ``Δedge = bbox_minus − bbox_plus``
+       for each of ``top, bottom, left, right``. The edge with
+       the largest ``|Δedge|`` is the **primary edge** driven by
+       this blade; ``slope = Δedge_primary / (−2 ·
+       blade_throw_mm)`` in pixels per mm.
+     - ``move_motor <blade> <baseline ± throw>``;
+       ``acquire_image``; bbox via NumPy mask.
+   * - 5
+     - **Report.** Per-blade: primary edge, signed pixel
+       displacement, motor throw, signed slope. Aggregate:
+       mean ``|slope|`` across H blades, mean across V blades,
+       per-axis spread, V/H mean ratio. Warns when:
+
+       - Same-axis spread > 5%.
+       - V/H ratio is outside ``[0.9, 1.1]``.
+     - log lines only; no PV writes.
+   * - 6
+     - **Restore.** Run by ``try / finally`` on every exit path.
+       All 4 blades restored to snapshot baseline, then camera
+       state restored. Blade restore is gated (default
+       ``announce_only`` -- single Enter to proceed) unless
+       ``--confirm-restore`` is set.
+     - ``_Snapshot.restore()`` → 4 ``move_motor`` calls + camera
+       caputs via ``safe_restore``.
+
+
+Postconditions
+--------------
+
+On **clean completion**:
+
+- All 4 blade motors are back at their pre-procedure baselines
+  (within motor positioning tolerance; verified by
+  ``move_motor``'s ``DMOV`` wait).
+- Camera state restored to the operator's pre-procedure values.
+- Console + cora log contain the per-blade slope table and the
+  per-axis aggregate report.
+- Slit virtual motors (``Slit*Hsize`` / ``Vcenter`` etc.) are
+  **untouched** -- this procedure drives the underlying motor
+  records directly.
+
+On **abort**:
+
+- Same: all 4 blades restored, camera restored. The aggregate
+  report covers only the blades that completed both ``+throw``
+  and ``−throw`` measurements; partial blades are listed with
+  ``primary_edge="?"`` and ``slope = 0``.
+
+
+Failure modes
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Symptom
+     - Recovery
+   * - ``OperatorAbort`` at any gate.
+     - ``try / finally`` runs restore: all blades back to baseline,
+       camera back to snapshot. Re-launch when ready.
+   * - "could not measure baseline spot centroid" at step 3.
+     - Open the slits enough that a spot is visible
+       (``Hsize, Vsize ≥ blade_throw_mm + spot margin``). Common
+       cause: forgot to reopen after the rezero phase of
+       :doc:`item_011`.
+   * - "only N pixels above threshold" warning during bbox
+       measurement.
+     - The spot is too small inside the ROI, or the multilayer
+       stripes are pushing the MAD-derived ``σ`` so high that
+       even the spot doesn't beat threshold. Try:
+
+       - ``--bg-sigma-threshold 3.0`` (looser threshold), or
+       - ``--frames-per-measurement 4`` (lower per-frame jitter
+         from stripes), or
+       - increase ``--edge-roi-half-size-pix`` if the ROI is too
+         small relative to the spot.
+   * - V/H ratio noticeably off 1.0 (e.g. 1.55).
+     - Not a failure -- this is the diagnostic signal the
+       procedure was written to expose. Indicates the
+       motor-record calibration (``.MRES``, ``.ERES``, gear
+       ratio) of one axis pair is off by the reported ratio.
+       Compare to same-axis spread: if both V blades agree but
+       both H blades agree too, the IOC mis-calibrates the
+       whole axis; if one specific blade is the outlier, that
+       single motor record needs attention.
+   * - Same-axis spread > 5%.
+     - The two blades within one axis disagree on mm-per-pixel.
+       The outlier blade is the suspect -- check its
+       ``.MRES`` / ``.ERES`` / encoder direction in the motor
+       IOC. Cross-reference against the device-asset rows in
+       :doc:`../manual/item_020` for that station.
+
+
+Operator walkthrough
+--------------------
+
+- Run :doc:`item_011` first to centre + close + rezero + reopen
+  the chosen station's slits, ending with a centred 1 × 1 mm
+  aperture. The spot should be roughly in the middle of the
+  detector frame.
+- Launch with default flags; ``--slit-station B`` is the
+  default. To diagnose the A station, pass ``--slit-station A``.
+- The first prompt is the ``+throw`` move of the first blade
+  (e.g. ``2bma:m9.VAL`` → ``baseline + 0.5 mm``). Confirm
+  ``y`` -- the move should be visible on the live view as the
+  spot's top or bottom (or left / right) edge shifting.
+- Each blade triggers 3 gates: ``+throw``, ``−throw``,
+  ``restore``. After all 12, the per-blade slope table and the
+  aggregate report appear in the console.
+- A V/H ratio close to 1.0 (within ~5%) is the expected outcome
+  on a healthy station; anything substantially off is a finding
+  worth taking up with the motor IOC config.
+
+
+Notes
+-----
+
+- The procedure does NOT auto-fix the calibration: it only
+  identifies which blade(s) are wrong. The fix is a manual edit
+  in the motor IOC substitution file followed by an IOC restart.
+- "Primary edge" detection is heuristic but robust: a blade
+  motion of order 0.5 mm typically shifts one bbox edge by
+  ~100-200 pixels while the other three change by < 10 pixels
+  (residual jitter from the centroid). The argmax is reliable
+  in this regime.
+- If two edges shift by comparable amounts, the blade may be
+  mis-mounted (driving a diagonal instead of an axis) -- the
+  output dict ``all_edge_changes`` is logged so the operator can
+  see all four edges and judge.
+- Open trigger this procedure creates: extend the cora ``Slit``
+  Asset for each station with per-blade ``calibration_slope_pix_per_mm``
+  fields populated from this procedure's report (one record per
+  blade motor).

--- a/docs/source/procedures/item_012.rst
+++ b/docs/source/procedures/item_012.rst
@@ -344,3 +344,118 @@ Notes
   Asset for each station with per-blade ``calibration_slope_pix_per_mm``
   fields populated from this procedure's report (one record per
   blade motor).
+
+
+Field-test results (v0.0.2, 2026-06-14)
+---------------------------------------
+
+First end-to-end runs on both 2-BM stations. Surfaced and fixed
+a long-standing V-blade miscal on A; confirmed B is healthy.
+
+:Camera: FLIR Oryx 31MP at ``2bmSP2:`` via MCTOptics
+:Lens: 1.1× (slot 0)
+:Camera binning: 2 × 2
+:Frames per measurement: 4
+:Blade throw: ±0.25 mm
+
+A station — before MRES fix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============= ============ ============ ===================
+blade         primary edge slope px/mm  notes
+============= ============ ============ ===================
+``2bma:m13``  left         339.8        H+ (X+, outboard)
+``2bma:m14``  right        328.0        H− (X−, inboard)
+``2bma:m15``  bottom       506.8        V+ (Y+, up)
+``2bma:m16``  top          486.4        V− (Y−, down)
+============= ============ ============ ===================
+
+- H mean = 334 px/mm, V mean = 497 px/mm, **V/H = 1.487** ← WARN.
+- Same-axis spread: H 3.5%, V 4.1% (both blades within an axis
+  agree; whole-axis V miscal, not single-blade).
+- Cross-checked against the operator's pre-existing workaround
+  ("setting Vsize = 0.6 mm with Hsize = 1.0 mm gives a square
+  image on the detector") and against a hand-bbox of an earlier
+  PNG showing the same 1.55× V/H aspect.
+
+Root cause: the motor IOC substitution file
+(``/net/s2dserv/xorApps/epics/synApps_5_8/ioc/2bma/iocBoot/ioc2bma/motor.substitutions``)
+uses a single template for every motor m1..m44+ — all share
+``MRES = 2.5e-4``, ``EGU = "degrees"``, ``VELO = 1``. The per-
+axis mechanical differences between the A H blade assembly and
+the A V blade assembly were never compensated.
+
+Fix (applied live via ``caput`` with the SET/Use position-
+redefinition pattern, persisted via autosave):
+
+.. code-block:: bash
+
+   # For each of m15 and m16:
+   caput 2bma:m15.VAL 0       # park at known position
+   caput 2bma:m15.SET 1       # enter position-redefine mode
+   caput 2bma:m15.MRES 5.95e-4  # = 4e-4 (old) × 1.487 (correction factor)
+   caput 2bma:m15.VAL 0       # relabel position in new units (0 → 0)
+   caput 2bma:m15.SET 0       # exit Set mode
+
+A station — after MRES fix
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============= ============ ============ ===================
+blade         primary edge slope px/mm  notes
+============= ============ ============ ===================
+``2bma:m13``  left         339.7        unchanged ✓
+``2bma:m14``  right        328.0        unchanged ✓
+``2bma:m15``  bottom       350.4        MRES 4e-4 → 5.95e-4
+``2bma:m16``  top          322.3        MRES 4e-4 → 5.95e-4
+============= ============ ============ ===================
+
+- H mean = 334 px/mm, V mean = 336 px/mm, **V/H = 1.008** ← PASS.
+- Same-axis spread: H 3.5%, V 8.4% (V borderline; likely tighten
+  with ``--frames-per-measurement 8``).
+- Visually validated: Hsize = Vsize = 1.0 mm now produces a
+  square aperture image on the detector.
+
+B station (no fix needed)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============= ============ ============ ===================
+blade         primary edge slope px/mm  notes
+============= ============ ============ ===================
+``2bma:m9``   top          170.0        V+ (Y+, up)
+``2bma:m10``  bottom       172.0        V− (Y−, down)
+``2bma:m11``  left         168.3        H pair
+``2bma:m12``  right        167.5        H pair
+============= ============ ============ ===================
+
+- H mean = 167.9 px/mm, V mean = 171.0 px/mm,
+  **V/H = 1.019** ← PASS.
+- Same-axis spread: H 0.5%, V 1.2% (textbook).
+- B slopes are ~½ of A's, matching the 2× geometric magnification
+  of A's projection at the detector plane (A at z = 25225 mm, B
+  and detector both at z ≈ 50500 mm).
+
+Notes from the field test
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **DMM image flip.** A's blade-to-edge mapping is mirrored from
+  :doc:`../manual/item_020`'s labels (m13 = H+ outboard moves the
+  LEFT edge of the spot; m15 = V+ up moves the BOTTOM edge). B's
+  mapping is straight (m9 = V+ moves the TOP edge). The DMM
+  Bragg reflection between A and B inverts one axis of A's image
+  relative to B's at the detector. Worth knowing for any future
+  blade-direction debugging.
+- **A V-blade tilt.** Even after the MRES fix, the centring-
+  sensitivity matrix (from :doc:`item_011`) shows H_sens = 330
+  px/mm but V_sens = 134 px/mm — a factor 2.5 asymmetry that the
+  blade-throw procedure doesn't see (both axes give ~334 px/mm
+  per blade). The discrepancy is consistent with a small tilt
+  on the V blade pair that smears the V intensity profile, so
+  the COM tracks the slit centre less than 1:1 when Vcenter
+  moves. Not a calibration error — a geometric fact about A's V
+  kinematic. B's centring sensitivity is much more symmetric
+  (H_sens = 170, V_sens = 109, ratio 1.55) consistent with B
+  not having the same tilt.
+
+Run details and the architectural / bug history that got here
+are in `2bm-procedures CHANGELOG
+<https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__.


### PR DESCRIPTION
## Summary

14 commits since the last merged PR; ~1250 line additions across 7 files. Three thematic threads:

1. **Two new procedure specs.** `item_011` (`centre_and_close_slits`, 447 lines) and `item_012` (`calibrate_slit_blade_throw`, 461 lines) — full operator-facing specs with parameters, steps, postconditions, failure modes, and field-test results from real 2-BM runs on 2026-06-14.
2. **`item_002` field-tested.** First end-to-end convergent run of `detector_z_rail_alignment` on 2-BM-B: `|tilt|` drove 431 → 26 µrad in 5 iterations (M condition 1.1, geometric decay matching `damping=0.5` to ~1%, final residual at the PRO225SL rail straightness floor). Field-test table added. Centroid algorithm now selectable; `--frames-per-measurement` documented.
3. **`item_020` cora-readiness + a Flag location correction.** Slit blocks (A and B) gain the same cora-vocabulary structure already present on cora-bound Assets (`:cora Asset:`, `:Driven by:`, virtual-motor PV tables with HOPR/LOPR limits, "cora Asset registration intent" notes). Diagnostic Flag block moved from "upstream of L3 Slits" to its correct location between DMM and the P6-50 safety shutter at z = 32500 mm. Layout map updated to match.

Plus one cross-cutting refactor in the last commit: **renamed every 2-BM Asset reference to cora's role-name convention** per [cora-doga PR #111](https://github.com/xmap/cora/pull/111) (2026-06-14). The Asset name now carries only the role; vendor / IOC / station identifiers move to the bound Model + `alternate_identifiers`. Affects 5 files in this PR (`manual/item_020.rst`, `procedures/item_001.rst`, `procedures/item_002.rst`, `procedures/item_009.rst`, `procedures.rst`).

## What's in each file

| file | lines | thrust |
|------|------:|--------|
| `manual/item_020.rst` | +338 / −121 | Flag z-position correction + cora-ready Slit blocks (`:cora Asset:`, `:Driven by:`, virtual-motor PV tables for both A and B with HOPR/LOPR + shared-IOC note); role-name convention applied to Hexapod / Rotary / Focus / SampleTop / Mirror / drives |
| `procedures/item_011.rst` | +447 NEW | `centre_and_close_slits` spec: four phases (calibrate centring, iterate, close, rezero, reopen), per-station (`--slit-station A | B`), final-state matrix |
| `procedures/item_012.rst` | +461 NEW | `calibrate_slit_blade_throw` spec: per-blade `pixels-per-mm` slope diagnostic, V/H ratio + same-axis spread flags, field-test tables (A before/after MRES fix, B baseline), DMM image-flip notes |
| `procedures/item_002.rst` | +103 / −0 | v0.0.1 field-test convergence table; centroid-algorithm selection documented; `--frames-per-measurement` documented |
| `procedures.rst` | +22 / −5 | Index entries for item_011 + item_012; role-name updates |
| `procedures/item_001.rst` | +1 / −1 | Role-name update |
| `procedures/item_009.rst` | +2 / −2 | Role-name update |

## Notable cora-side renames (applied throughout)

| previously | now |
|---|---|
| `A_station_slits` | `ConditioningSlit` |
| `B_station_slits` | `SampleSlit` |
| `Hexapod_2BM` | `Hexapod` |
| `Aerotech_ABRS_rotary` | `Rotary` |
| `Optique_Peter_focus_Z` | `Focus` |
| `Sample_top_X` / `Sample_top_Z` | `SampleTop_X` / `SampleTop_Z` |
| `Sample_pitch_lam` | `LaminographyPitch` |
| `Aerotech_Hexapod_drive` | `HexapodDrive` |
| `Aerotech_Ensemble_drive` | `RotaryDrive` |
| `Aerotech_2bmbAERO_drive` | `FocusDrive` |
| `OMS_VME58_2bma_drive` | `FrontEndDrive` |
| `OMS_VME58_2bmb_drive` | `SampleStageDrive` |
| `Y3-30_mirror` | `Mirror` |
| `Detector_optical_table` | `DetectorTable` (cora's pending `2bm-detector-optical-table` branch) |

## Field-test evidence captured in this PR

- **`item_002`** (`detector_z_rail_alignment` v0.0.1, 2026-06-14): `|tilt|` 431 → 26 µrad in 5 iterations, M cond = 1.1.
- **`item_012`** (`calibrate_slit_blade_throw` v0.0.2, 2026-06-14):
  - A station before MRES fix: V/H = 1.487 (WARN; V over-scaled by 49%)
  - A station after MRES fix (m15/m16 .MRES 4e-4 → 5.95e-4): V/H = 1.008
  - B station baseline: V/H = 1.019, same-axis spreads ≤ 1.2%

## Validation

- [x] `make html` builds clean (only 4 pre-existing unrelated toctree warnings; none introduced by this PR)
- [x] All cora Asset names verified against `cora-doga/docs/deployments/2-bm/assets.md` as of 2026-06-14
- [x] All EPICS PVs in updated tables (Slit1Hsize/Hcenter/Vsize/Vcenter HOPR/LOPR; A blade motor numbers m13–m16; Flag z = 32500 mm) confirmed live via `caget` on 2026-06-14

## Test plan

- [ ] Reviewer: confirm rendered HTML for `manual/item_020.rst` shows the Flag block in the correct DMM → Flag → B-shutter sequence
- [ ] Reviewer: confirm rendered HTML for `procedures/item_011.rst` and `procedures/item_012.rst` shows complete spec pages with parameter tables, step tables, and field-test tables formatting correctly
- [ ] Reviewer (cora dev): confirm proposed Asset names (`ConditioningSlit`, `SampleSlit`, `DetectorTable`, etc.) match the convention used in the latest `cora-doga` `assets.md` and that the "cora Asset registration intent" notes are usable as-is for future Asset registration

## Commits

```
e83afbd docs: rename 2-BM Assets to cora's role-name convention (cora #111)
1b612f9 docs(item_020): add A-station virtual-motor PV table; reframe shared IOC
aad51d9 docs(item_020): make A/B Slit blocks cora-ready
0447b79 docs(item_012): add field-test results section for v0.0.2
78df328 docs(item_020): correct Flag z position and physical location
ef74a03 docs(procedures): add item_012 calibrate_slit_blade_throw spec
0faaf78 docs(procedures): relaxed centring defaults match procedure
1a50ddb docs(procedures): document phase 4 reopen + final-state matrix
a4aa82f docs(procedures): document rezero phase in centre_and_close_slits
c3c9ed8 docs: B-station slit virtual motors + centre_and_close_slits spec
8bd1625 docs(procedures): item_002 field-test results (v0.0.1, 2026-06-14)
6ed83ff docs(procedures): document --frames-per-measurement
1904dba docs(procedures): centroid algorithm now selectable; com is default
a9f946a docs(procedures): centroid algorithm change (binary mask + median+MAD)
```
