### PR TITLE
docs(procedures): make stub-procedures heading self-describing

### DIFF
--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -57,8 +57,8 @@ Current procedures
   on the cora side.
 
 
-Stub procedures (precondition targets of item_002)
-==================================================
+Stub procedures (preconditions of :doc:`procedures/item_002`)
+=============================================================
 
 These pages exist so the precondition graph of
 :doc:`procedures/item_002` has named targets to link to. Each is a


### PR DESCRIPTION
## Summary

One-line wording fix on `docs/source/procedures.rst`. The "Stub procedures" section heading required the reader to already know what `item_002` refers to:

```
Stub procedures (precondition targets of item_002)
```

Replace with a `:doc:` cross-reference that renders as a clickable link to `detector_z_rail_alignment` — the procedure whose preconditions the stubs satisfy:

```
Stub procedures (preconditions of :doc:`procedures/item_002`)
```

Section underline retrimmed to match the new heading length.

## Test plan

- [x] `make html` builds clean (no new warnings)
- [ ] Reviewer: confirm rendered HTML shows the heading with `detector_z_rail_alignment` (or `item_002`, depending on the `:doc:` title resolution) as a clickable link

## Commits

```
b95d8bd docs(procedures): make stub-procedures heading self-describing
```