### PR TITLE
docs: fix sidebar heading; convert slit virtual-motor tables to list-table

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -254,14 +254,25 @@ L3 Slits
    set on the screen propagate through downstream calc records to
    the individual blade motors.
 
-   =========================  ======================  =====================
-   PV                         Role                    Limits (HOPR / LOPR)
-   =========================  ======================  =====================
-   ``2bma:Slit1Hsize``        Horizontal aperture mm  +93.95 / -24.05
-   ``2bma:Slit1Hcenter``      Horizontal centre mm    +34.73 / -24.27
-   ``2bma:Slit1Vsize``        Vertical aperture mm    +71.29 / -66.71
-   ``2bma:Slit1Vcenter``      Vertical centre mm      +23.47 / -45.53
-   =========================  ======================  =====================
+   .. list-table::
+      :header-rows: 1
+      :widths: 30 40 30
+
+      * - PV
+        - Role
+        - Limits (HOPR / LOPR)
+      * - ``2bma:Slit1Hsize``
+        - Horizontal aperture mm
+        - +93.95 / -24.05
+      * - ``2bma:Slit1Hcenter``
+        - Horizontal centre mm
+        - +34.73 / -24.27
+      * - ``2bma:Slit1Vsize``
+        - Vertical aperture mm
+        - +71.29 / -66.71
+      * - ``2bma:Slit1Vcenter``
+        - Vertical centre mm
+        - +23.47 / -45.53
 
 The slits at 2-BM are standard APS L3-20. Technical as-built drawings
 are available `here <https://anl.box.com/s/sgmoux6db8tsx71pvifzkf2ajopfidqx>`_.
@@ -805,14 +816,25 @@ B-station Slits
    ``Center`` values you set on the screen propagate through
    downstream calc records to the individual blade motors.
 
-   =========================  ======================  =====================
-   PV                         Role                    Limits (HOPR / LOPR)
-   =========================  ======================  =====================
-   ``2bma:Slit2Hsize``        Horizontal aperture mm  +45.50 / -112.50
-   ``2bma:Slit2Hcenter``      Horizontal centre mm    +37.08 / -41.92
-   ``2bma:Slit2Vsize``        Vertical aperture mm    +115.62 / -34.13
-   ``2bma:Slit2Vcenter``      Vertical centre mm      +52.28 / -22.60
-   =========================  ======================  =====================
+   .. list-table::
+      :header-rows: 1
+      :widths: 30 40 30
+
+      * - PV
+        - Role
+        - Limits (HOPR / LOPR)
+      * - ``2bma:Slit2Hsize``
+        - Horizontal aperture mm
+        - +45.50 / -112.50
+      * - ``2bma:Slit2Hcenter``
+        - Horizontal centre mm
+        - +37.08 / -41.92
+      * - ``2bma:Slit2Vsize``
+        - Vertical aperture mm
+        - +115.62 / -34.13
+      * - ``2bma:Slit2Vcenter``
+        - Vertical centre mm
+        - +52.28 / -22.60
 
    *(Earlier doc attempts referred to* ``2bma:Slit2H:size`` *with a
    colon — that is NOT the name. The canonical names are no-colon

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -57,8 +57,8 @@ Current procedures
   on the cora side.
 
 
-Stub procedures (preconditions of :doc:`procedures/item_002`)
-=============================================================
+Stub procedures
+===============
 
 These pages exist so the precondition graph of
 :doc:`procedures/item_002` has named targets to link to. Each is a


### PR DESCRIPTION
## Summary

Three small layout fixes in one commit; no content changes (PVs, roles, HOPR/LOPR values all identical to before).

1. **`procedures.rst` sidebar heading.** The "Stub procedures" section title had a `:doc:` cross-reference embedded in it — Sphinx rendered the main-content heading correctly (substituting in the target page title `detector_z_rail_alignment`) but the left-sidebar navigation entry showed the broken fragment `/item_002)` because Sphinx doesn't resolve `:doc:` titles in toctree entries the same way it does in main content. Heading is now plain `Stub procedures`; the `:doc:` link to item_002 stays in the intro paragraph immediately below, where rendering is unaffected.

2. **`manual/item_020.rst` L3 Slits virtual-motor table.** Converted from a simple-table (with 25-character header underlines forcing wider-than-page rendering) to a `list-table` directive with explicit `:widths: 30 40 30`. Same pattern as the existing DMM motors table elsewhere in this file.

3. **`manual/item_020.rst` B-station Slits virtual-motor table.** Same conversion, same widths.

## What's in each file

| file | lines | thrust |
|------|------:|--------|
| `manual/item_020.rst` | +36 / −18 | Two simple-tables → `list-table` (L3 Slits + B-station Slits virtual-motor PV tables); identical content |
| `procedures.rst` | +2 / −2 | "Stub procedures" heading simplified; `:doc:` link to item_002 already present in intro paragraph below |

## Validation

- [x] `make html` builds clean (no new warnings)
- [x] Identical PVs, roles, and HOPR/LOPR values verified by line-by-line comparison against the prior simple-table form

## Test plan

- [ ] Reviewer: confirm rendered sidebar navigation shows the heading as "Stub procedures" (not "/item_002)")
- [ ] Reviewer: confirm both Slit virtual-motor tables render within the page content width (no horizontal scrollbar)

## Commits

```
88a2636 docs: fix sidebar heading; convert slit virtual-motor tables to list-table
```
