### PR TITLE
docs: Source links on every procedure page; rename Focus → PropagationDistance

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1378,24 +1378,29 @@ offsets are held in the IOC's autosave file.
    ``Default`` button restores the per-combination calibrated
    focus / rotation values from the IOC's autosave file.
 
-Focus
------
+PropagationDistance
+-------------------
 
-(cora Asset identifier; previously called "Optique Peter Z stage"
-in this page.)
+(cora Asset identifier. Previously called ``Focus`` (cora #111)
+and "Optique Peter Z stage" (this page); both names were
+misleading — this stage controls the sample-to-detector distance
+along the beam, NOT lens focus. The propagation distance is what
+the operator increases for phase-contrast imaging.)
 
-:Role: Carries the entire microscope body along the beam from
-   near-contact with the sample out to ~1 m for phase-contrast
-   imaging.
+:Role: Sample-to-detector Z stage. Carries the entire microscope
+   body along the beam from near-contact with the sample out to
+   ~1 m, varying the **propagation distance** used to control
+   inline phase contrast.
 :Family: LinearStage
 :Model: Aerotech **PRO225SL-1000** mechanical-bearing linear stage
    (SL precision class, 1000 mm travel; the longest member of the
    PRO225SL family). cora Model: ``aerotech_pro225sl_1000``.
 :Mounted on: Detector optical table
 :Carries: Optique Peter MICRX080 microscope
-:Driven by: ``FocusDrive`` (cora ``MotionController``
+:Driven by: ``PropagationDistanceDrive`` (cora ``MotionController``
    Asset wrapping the Aerotech drive that the ``2bmbAERO`` IOC
-   manages)
+   manages; was ``FocusDrive`` in cora #111, renamed to match the
+   stage it drives)
 :Travel: 1000 mm
 :Accuracy: ±18 µm (SL Standard; calibrated grade not offered above 500 mm)
 :Resolution: 0.1 µm (high-resolution feedback) / 1.0 µm

--- a/docs/source/procedures/item_001.rst
+++ b/docs/source/procedures/item_001.rst
@@ -18,6 +18,7 @@ sections below map onto cora as follows:
 Section                 Maps to in cora
 ======================  ====================================================
 **Name**                ``Method.name``
+**Source**              Links to the Python implementation + release notes
 **Devices**             ``Plan.wiring`` targets (Assets from item_020)
 **Preconditions**       Guard clauses checked before the Method runs
 **Parameters**          ``Method.parameters_schema``
@@ -41,6 +42,22 @@ Name
 
 ``procedure_short_identifier``
 *(required — snake_case; becomes ``Method.name`` in cora)*
+
+
+Source
+------
+
+*(required — links to the Python implementation in
+`2bm-procedures <https://github.com/decarlof/2bm-procedures>`__
+and to its CHANGELOG entry. For stub pages prior to
+implementation, replace the bullets with a "Not yet implemented.
+Future location: procedures/SLUG.py ..." note. Substitute the
+actual snake_case procedure slug for the literal* ``SLUG`` *below.)*
+
+- **Implementation**: `procedures/SLUG.py
+  <https://github.com/decarlof/2bm-procedures/blob/main/procedures/SLUG.py>`__
+- **Release notes**: `2bm-procedures CHANGELOG
+  <https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__
 
 
 Devices

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -23,10 +23,19 @@ Name
 ``detector_z_rail_alignment``
 
 
+Source
+------
+
+- **Implementation**: `procedures/detector_z_rail_alignment.py
+  <https://github.com/decarlof/2bm-procedures/blob/main/procedures/detector_z_rail_alignment.py>`__
+- **Release notes**: `2bm-procedures CHANGELOG
+  <https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__
+
+
 Devices
 -------
 
-- :doc:`../manual/item_020`: **Focus** —
+- :doc:`../manual/item_020`: **PropagationDistance** —
   ``2bmbAERO:m1`` (Aerotech PRO225SL-1000, 1 m travel).
 - :doc:`../manual/item_020`: **Detector optical table** —
   synApps ``table.db`` composite ``2bmb:table3``; corrective DoFs
@@ -526,7 +535,7 @@ Postconditions
 - ``2bmb:table3.AY`` and ``.AX`` are at the converged values;
   their new positions are logged. (Procedure deliberately does
   not restore these — they're the output.)
-- ``Focus`` is back at its pre-procedure RBV
+- ``PropagationDistance`` is back at its pre-procedure RBV
   (restored from snapshot).
 - All snapshotted camera state is back to its pre-procedure
   values: if the camera was running Continuous on entry, it is
@@ -693,11 +702,15 @@ Notes
   cannot make the call hang. All of these are restored from
   snapshot at exit.
 - This procedure is **not** the same as cora's stubbed
-  ``resolution_alignment`` (which targets the same
-  ``Focus`` Asset but optimises **lens focus**
-  on a fixed sample, not the rail-to-beam angular alignment).
-  Both procedures share Assets but operate on different
-  physical surfaces.
+  ``resolution_alignment``. The two touch different Assets
+  entirely: ``resolution_alignment`` optimises **lens focus**
+  via the MCTOptics per-lens focus values (saved by the IOC
+  per camera + lens combination), while this procedure walks
+  the ``PropagationDistance`` rail stage (``2bmbAERO:m1``) to
+  fit and correct rail-to-beam angular alignment. The earlier
+  shared-Asset framing in this page reflected the now-corrected
+  misconception that ``2bmbAERO:m1`` was a lens-focus motor;
+  it is in fact the sample-to-detector Z (propagation) stage.
 - Open trigger this procedure creates: register a
   ``DetectorTable`` Asset (Family ``OpticalTable``) in
   ``cora/docs/deployments/2-bm/assets.md``, then add a

--- a/docs/source/procedures/item_003.rst
+++ b/docs/source/procedures/item_003.rst
@@ -16,6 +16,15 @@ Name
 ``enable_beamline``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/enable_beamline.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/enable_beamline.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_004.rst
+++ b/docs/source/procedures/item_004.rst
@@ -16,6 +16,15 @@ Name
 ``set_a_slits``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/set_a_slits.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/set_a_slits.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -16,6 +16,18 @@ Name
 ``set_energy_to_preselect``
 
 
+Source
+------
+
+Not yet implemented in this repository. Future location: `procedures/set_energy_to_preselect.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/set_energy_to_preselect.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository. Likely a
+thin wrapper around the `energy
+<https://github.com/xray-imaging/energy>`__ package, which already
+implements the coordinated DMM + mirror energy change.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_006.rst
+++ b/docs/source/procedures/item_006.rst
@@ -17,6 +17,15 @@ Name
 ``set_flag_in``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/set_flag_in.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/set_flag_in.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_007.rst
+++ b/docs/source/procedures/item_007.rst
@@ -16,6 +16,15 @@ Name
 ``open_b_shutter``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/open_b_shutter.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/open_b_shutter.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_008.rst
+++ b/docs/source/procedures/item_008.rst
@@ -16,6 +16,15 @@ Name
 ``set_b_slits``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/set_b_slits.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/set_b_slits.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_009.rst
+++ b/docs/source/procedures/item_009.rst
@@ -16,6 +16,15 @@ Name
 ``move_sample_out_of_beam``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/move_sample_out_of_beam.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/move_sample_out_of_beam.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_010.rst
+++ b/docs/source/procedures/item_010.rst
@@ -16,6 +16,15 @@ Name
 ``configure_microscope_for_alignment``
 
 
+Source
+------
+
+Not yet implemented. Future location: `procedures/configure_microscope_for_alignment.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/configure_microscope_for_alignment.py>`__
+in the `2bm-procedures
+<https://github.com/decarlof/2bm-procedures>`__ repository.
+
+
 Devices
 -------
 
@@ -25,9 +34,10 @@ Devices
 - :doc:`../manual/item_020`: **Detector optical table** —
   ``2bmb:table3``; the ``.Y`` translation axis sets the table
   vertical position so the X-ray beam lands on the camera centre.
-- :doc:`../manual/item_020`: **Optique Peter Z stage** —
-  ``2bmbAERO:m1``; pre-positioned to a safe mid-band Z before the
-  alignment procedure runs.
+- :doc:`../manual/item_020`: **PropagationDistance** —
+  ``2bmbAERO:m1`` (the sample-to-detector Z stage; was named
+  "Optique Peter Z stage" / ``Focus`` previously). Pre-positioned
+  to a safe mid-band Z before the alignment procedure runs.
 
 
 Preconditions

--- a/docs/source/procedures/item_011.rst
+++ b/docs/source/procedures/item_011.rst
@@ -30,6 +30,15 @@ Name
 ``centre_and_close_slits``
 
 
+Source
+------
+
+- **Implementation**: `procedures/centre_and_close_slits.py
+  <https://github.com/decarlof/2bm-procedures/blob/main/procedures/centre_and_close_slits.py>`__
+- **Release notes**: `2bm-procedures CHANGELOG
+  <https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__
+
+
 Devices
 -------
 

--- a/docs/source/procedures/item_012.rst
+++ b/docs/source/procedures/item_012.rst
@@ -29,6 +29,15 @@ Name
 ``calibrate_slit_blade_throw``
 
 
+Source
+------
+
+- **Implementation**: `procedures/calibrate_slit_blade_throw.py
+  <https://github.com/decarlof/2bm-procedures/blob/main/procedures/calibrate_slit_blade_throw.py>`__
+- **Release notes**: `2bm-procedures CHANGELOG
+  <https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__
+
+
 Devices
 -------
 


### PR DESCRIPTION
Two commits, 13 files, ~130 line additions. Both came out of operator review of the rendered docs.

1. **Every procedure spec page now links back to its Python implementation.** Previously the spec pages described what each procedure does but a reader had to know to go look in `decarlof/2bm-procedures` for the code. Added a `Source` subsection between `Name` and `Devices` on every procedure page (item_002, item_003-010, item_011, item_012) plus the template (item_001).

2. **`Focus` (cora #111) renamed to `PropagationDistance`.** The Aerotech PRO225SL-1000 at `2bmbAERO:m1` does NOT control lens focus — it controls sample-to-detector distance along the beam, which the operator increases to enhance inline phase contrast. The name `Focus` inherited from cora #111 (and from the earlier upstream name `Optique_Peter_focus_Z` here) was therefore wrong and propagating a real misconception. Renamed across `item_020`, `item_002`, and `item_010`; matching rename of `target_asset_ids` in `2bm-procedures detector_z_rail_alignment.py` shipped in a companion commit on that repo.

## What's in each file

| file | lines | thrust |
|------|------:|--------|
| `manual/item_020.rst` | +16 / −11 | `Focus` section → `PropagationDistance`. Intro note expanded to call out both prior misnamings (`Focus` from cora #111 and `Optique_Peter_focus_Z` from this page) so the misconception doesn't recur. `:Role:` rewritten to describe the propagation-distance function explicitly. `:Driven by:` updated from `FocusDrive` → `PropagationDistanceDrive`. |
| `procedures/item_001.rst` | +17 | Template: cora-mapping table gains a `Source` row; `Source` subsection added with `SLUG` placeholder. |
| `procedures/item_002.rst` | +20 / −7 | Source section added (`procedures/detector_z_rail_alignment.py` + CHANGELOG). Three `Focus` cross-references → `PropagationDistance`. The Notes paragraph about `resolution_alignment` rewritten — that procedure does NOT share an Asset with `detector_z_rail_alignment` after all; it touches the MCTOptics per-lens focus values, not the propagation stage. The earlier shared-Asset framing was a consequence of the same misnaming. |
| `procedures/item_003.rst` | +9 | Source section: `Not yet implemented. Future location: procedures/enable_beamline.py …` |
| `procedures/item_004.rst` | +9 | Same shape for `set_a_slits`. |
| `procedures/item_005.rst` | +12 | Same shape for `set_energy_to_preselect`. Additionally notes that the underlying coordinated DMM + mirror energy change is already implemented in the `energy` package — a future wrapper would likely call into it. |
| `procedures/item_006.rst` | +9 | Same shape for `set_flag_in`. |
| `procedures/item_007.rst` | +9 | Same shape for `open_b_shutter`. |
| `procedures/item_008.rst` | +9 | Same shape for `set_b_slits`. |
| `procedures/item_009.rst` | +9 | Same shape for `move_sample_out_of_beam`. |
| `procedures/item_010.rst` | +13 / −3 | Source section: `Not yet implemented. Future location: procedures/configure_microscope_for_alignment.py …`. Devices entry "Optique Peter Z stage" → "PropagationDistance" (with parenthetical noting prior names). |
| `procedures/item_011.rst` | +9 | Source section linking to `procedures/centre_and_close_slits.py` + CHANGELOG. |
| `procedures/item_012.rst` | +9 | Source section linking to `procedures/calibrate_slit_blade_throw.py` + CHANGELOG. |

## Why the Focus → PropagationDistance rename

Background:
- The Aerotech PRO225SL-1000 at `2bmbAERO:m1` is a 1 m linear stage that carries the entire Optique Peter microscope along the beam axis.
- Operator workflow: pull the detector away from the sample to increase the propagation distance, which sharpens edge-enhancing phase contrast in inline geometry.
- Original 2-BM page (this repo) named the Asset `Optique_Peter_focus_Z` — the `_focus_` infix was a misnomer that nobody had flagged.
- cora's role-name refactor (PR #111) simplified the misnamed Asset to `Focus`, inheriting the same misconception.
- Operator noticed during doc review and corrected: this motor varies **propagation distance**, not lens focus. Lens focus is set per-(camera, lens) combination by MCTOptics autosave; it's a separate concern entirely.

Rename map applied:
- `Focus` → `PropagationDistance`
- `FocusDrive` → `PropagationDistanceDrive` (drive name follows the driven Asset, per cora's role-name convention)

## Validation

- [x] `make html` builds clean (no new warnings beyond the 4 pre-existing unrelated toctree warnings)
- [x] All 11 procedure pages render the Source subsection between Name and Devices
- [x] item_020 `Focus` section renamed; no broken cross-references after the rename
- [x] Matching `target_asset_ids` rename in `2bm-procedures detector_z_rail_alignment.py` already pushed (commit `a3fa02a` on `decarlof/main`)

## Test plan

- [ ] Reviewer: confirm rendered `procedures/item_002` (and item_011, item_012) shows the Source bullets with working links to `decarlof/2bm-procedures`
- [ ] Reviewer: confirm rendered `manual/item_020` shows the renamed `PropagationDistance` block (was `Focus`) with the corrected role description
- [ ] Reviewer: confirm the rewritten Notes paragraph at the bottom of `procedures/item_002` no longer implies `detector_z_rail_alignment` and `resolution_alignment` share an Asset

## Commits

```
5eb45b3 docs: rename Focus -> PropagationDistance (2bmbAERO:m1 is NOT a focus motor)
a821f8c docs(procedures): add Source section linking to 2bm-procedures repo
```

