### PR TITLE
confirm rotary, hexapod and propagation stage

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -545,7 +545,7 @@ Y3-30 Mirror
    ``docs/catalog/families.md``. Composes a mirror body with
    an in-vacuum stripe selector and an external optical-table
    sub-assembly carrying Y / X / Z stages.)
-:Mounted on: Optical table (``2bma:table1`` via the ``table_full`` IOC)
+:Mounted on: Optical table (six physical motors ``2bma:m1``–``2bma:m6``; the per-end Y motors are driven via ``2postMirror.db`` and the table X motors via the energy-change IOC; see the Mirror optical table block below)
 :Carries: (beam conditioning only)
 :z position: 27626 mm (ref 2: centre of optic; mirror-1 axis)
 :Position tolerance: 250 µm (x, y), 5 mm (z)
@@ -553,7 +553,7 @@ Y3-30 Mirror
 :Mirror length: 0.993 m (used by the angle calc record)
 :Reference drawing: 4105091203-300000
 :Reference (ops): https://docs2bm.readthedocs.io/en/latest/source/ops/item_045.html#mirror
-:MEDM screens: ``2postMirror.adl`` (Y / pitch control), ``table_full.adl`` (optical-table control)
+:MEDM screens: ``2postMirror.adl`` (Y / pitch control). ``table_full.adl`` was historically used for the ``2bma:table1`` composite axes; that record was dropped 2026-06-15 (see Mirror optical table block below) and the screen is no longer functional at runtime.
 :EPICS prefix: ``2bma:`` (motors listed per sub-system below)
 
 The APS reference-table entry reflects pre-APS-U geometry; the
@@ -592,10 +592,11 @@ into the IOC by:
 
 i.e. ``mDn`` (downstream) = ``2bma:m2``, ``mUp`` (upstream) =
 ``2bma:m5``, mirror length 0.9932 m for the angle calc. There are
-**exactly two physical Y motors** on the mirror itself; the
-``2bma:table1`` virtual record below also exposes Y axes, but those
-are the same two physical motors viewed as table corner supports
-(see the Optical table block and the m3 note there).
+**exactly two physical Y motors** on the mirror itself; these are
+the operational surface for fine pitch / angle setting via
+``2postMirror.adl``. See the Mirror optical table block below for
+why the table-level virtual record (``2bma:table1``) used to
+double-count them and has now been removed.
 
 **In-vacuum stripe selector.** The mirror has four horizontal coating
 stripes on its optical surface, selected by translating the mirror
@@ -617,95 +618,94 @@ stripe expected-flux curve (``mirror_multilayer_coating.png``).
    This coordination is encapsulated by the energy-change IOC; see
    :ref:`composite-iocs`.
 
-**Optical table.** The mirror sub-assembly sits on a multi-motor
-optical table that provides additional X (transverse) and Z
-(along-beam) translation and rotations. The table is driven through
-the ``table_full`` IOC, exposing the virtual table record
-``2bma:table1`` (composite). Loaded in the 2-BM-A IOC by
-``dbLoadRecords("$(DIR)/table.db", "P=2bma:,Q=Table1,T=table1,
-M0X=m1, M0Y=m2, M1Y=m3, M2X=m4, M2Y=m5, M2Z=m6, GEOM=SRI")``.
-Geometry is ``SRI`` (Sector Research Instrumentation: 3 Y supports,
-2 X supports, 1 Z support — 6 motors total), the same template
-used for the detector optical table; ``Translate`` / ``Rotate``
-columns on the screen are calc-driven composites of the underlying
-Motors column.
+**Mirror optical table.** The mirror sub-assembly sits on a
+multi-motor optical table whose six physical motors live on the
+``ioc2bma`` crate as ``2bma:m1`` through ``2bma:m6``. The table is
+**not exposed as a composite virtual record at 2-BM today** (the
+``2bma:table1`` record was historically loaded via ``table.db`` but
+has been removed — see note below). The six physical motors are
+driven via two separate, purpose-fit abstractions:
 
-Underlying motor map:
+- ``2postMirror.db`` for the mirror's pitch and vertical translation
+  (the per-end Y motors ``2bma:m2`` and ``2bma:m5``); operational
+  surface is ``2postMirror.adl``.
+- The energy-change IOC for the X support motors ``2bma:m1`` and
+  ``2bma:m4`` (the ``m1mox`` / ``m1m2x`` per-energy values driven in
+  coordinated moves with the in-vacuum stripe selector to reach the
+  highest-energy mirror stripes; see :ref:`composite-iocs`).
 
-=======  ============  ================================
-Macro    Motor PV      Role on the table
-=======  ============  ================================
-``M0X``  ``2bma:m1``   corner 0 — X support
-``M0Y``  ``2bma:m2``   corner 0 — Y support
-``M1Y``  ``2bma:m3``   **ERRONEOUS** — see warning below
-``M2X``  ``2bma:m4``   corner 2 — X support
-``M2Y``  ``2bma:m5``   corner 2 — Y support
-``M2Z``  ``2bma:m6``   corner 2 — Z support (single Z)
-=======  ============  ================================
+Per-motor role:
 
-The ``table.db`` template combines these into composite translate /
-rotate axes ``2bma:table1.X``, ``.Y``, ``.Z``, ``.AX``, ``.AY``,
-``.AZ``, plus per-leg readbacks under the ``2bma:table1:`` prefix.
+=========  =============================================================
+Motor PV   Role
+=========  =============================================================
+``2bma:m1``  Table X support, corner 0 (driven by energy-change IOC as ``m1mox``)
+``2bma:m2``  Mirror downstream Y (``M1 DSY``; per-end Y for pitch / vertical; ``2postMirror.adl`` operational surface; also ``mDn`` in ``2postMirror.db``)
+``2bma:m3``  In-vacuum X stripe selector (NOT a table support; see In-vacuum stripe selector block above)
+``2bma:m4``  Table X support, corner 2 (driven by energy-change IOC as ``m1m2x``)
+``2bma:m5``  Mirror upstream Y (``M1 USY``; per-end Y for pitch / vertical; ``2postMirror.adl`` operational surface; also ``mUp`` in ``2postMirror.db``)
+``2bma:m6``  Table Z support; present but not used operationally
+=========  =============================================================
 
 .. figure:: ../img/mirror_table.png
    :width: 480px
    :align: center
-   :alt: table_full.adl optical-table screen for 2bma:table1
+   :alt: table_full.adl optical-table screen for 2bma:table1 (historical)
 
-   ``table_full.adl`` for ``2bma:table1`` — optical-table control
-   screen. Translate / Rotate columns are calc-driven composites; the
-   Motors column drives the underlying stages (M0X, M0Y, M1Y, M2X,
-   M2Y, M2Z).
+   ``table_full.adl`` for ``2bma:table1``, **historical screenshot**.
+   This screen showed the table virtual record's composite axes
+   while ``table.db`` was loaded. As of 2026-06-15 the
+   ``2bma:table1`` record is no longer loaded (see note below); this
+   screen will show disconnected PVs at runtime and is kept here for
+   documentation of the prior configuration only.
 
-Operational status of each axis:
+.. note::
 
-- **M0X**, **M2X** (X support, ``2bma:m1`` / ``2bma:m4``): driven by
-  the **energy-change IOC** in coordinated moves with the in-vacuum
-  stripe selector to extend stripe-selector travel when reaching the
-  highest-energy mirror stripes. Per-energy values are stored as
-  ``m1mox`` / ``m1m2x`` in the energy IOC configuration (see
-  :ref:`composite-iocs`).
-- **M0Y**, **M2Y** (Y supports, ``2bma:m2`` / ``2bma:m5``):
-  physically the same per-end mirror Y motors documented above as
-  ``M1 DSY`` (downstream Y) and ``M1 USY`` (upstream Y) — viewed
-  once as raw motor records driven via ``2postMirror.adl`` (the
-  operational surface for fine pitch / angle setting) and once as
-  table Y corner supports via this virtual record.
-- **M1Y** (``2bma:m3``): **erroneous macro mapping** — see warning
-  below. ``2bma:m3`` is the in-vacuum stripe selector, not a table
-  Y support. The mirror table physically has only two Y supports
-  (``M0Y`` and ``M2Y`` above).
-- **M2Z** (Z support, ``2bma:m6``): along-beam translation; present
-  but not used operationally.
+   **History — ``2bma:table1`` virtual record removed 2026-06-15.**
 
-.. warning::
+   ``iocBoot/ioc2bma/st.cmd`` previously loaded the synApps
+   ``table.db`` template for this mirror table with the
+   substitution
+   ``"P=2bma:,Q=Table1,T=table1,M0X=m1, M0Y=m2, M1Y=m3, M2X=m4,
+   M2Y=m5, M2Z=m6, GEOM=SRI"``. That substitution had ``M1Y =
+   2bma:m3`` — but ``2bma:m3`` is the in-vacuum X stage that
+   translates the mirror inside the vacuum chamber (the stripe
+   selector), not a table Y corner support. The mirror table
+   physically has only **two** Y supports (the per-end DSY / USY
+   motors at ``2bma:m2`` / ``2bma:m5``, corroborated by the
+   ``2postMirror.db`` substitution above), so the ``M1Y`` slot in
+   the SRI 3-Y / 2-X / 1-Z template was structural padding
+   mistakenly filled with the stripe-selector motor record.
 
-   **``M1Y = m3`` in the table.db substitution above is an error.**
+   Consequence at the time: any move on ``2bma:table1.Y``, ``.AX``,
+   or ``.AY`` distributed through ``M1Y`` and would have perturbed
+   the in-vacuum stripe selector. The composite Y / pitch / yaw
+   axes on the table were therefore not safe to drive.
 
-   ``2bma:m3`` is the in-vacuum X stage that translates the mirror
-   inside the vacuum chamber (the stripe selector), confirmed by
-   beamline staff (2026-06-15). It cannot also be a table Y corner
-   support: a single motor record drives a single physical motor.
-   The mirror table physically has only TWO Y supports (corners 0
-   and 2), corroborated by the ``2postMirror.db`` loading line above
-   (``mDn=m2``, ``mUp=m5`` — exactly two per-end Y motors wired).
-   The ``M1Y`` macro slot in the ``GEOM=SRI`` template was filled
-   with ``2bma:m3`` likely because the template requires six motor
-   macros and an existing motor record was substituted as padding.
+   Three resolution paths were considered (tracked at
+   `xray-imaging/2bm-docs#171
+   <https://github.com/xray-imaging/2bm-docs/issues/171>`__):
 
-   Consequence: any move on ``2bma:table1.Y``, ``.AX``, or ``.AY``
-   that distributes through ``M1Y`` will perturb the in-vacuum
-   stripe selector. The composite Y / pitch / roll axes on this
-   table are therefore NOT safe to drive until the substitution is
-   fixed. Per-energy mirror Y is set via ``2postMirror.adl``
-   (driving ``2bma:m2`` and ``2bma:m5`` directly); per-energy
-   table-X moves via ``M0X`` and ``M2X`` are independent and
-   remain safe.
+   - **Path A** — substitute a soft motor record for ``M1Y`` so the
+     composite axes stay nominally functional but no longer touch
+     ``2bma:m3``.
+   - **Path B** — switch to ``ASRPmirrorTable.db`` (the synApps
+     mirror-table-specific template) which uses ``PITCH`` + ``VERT``
+     instead of 6 motors and matches the physical 2-Y geometry.
+   - **Path C** — drop the ``2bma:table1`` virtual record entirely;
+     drive the 6 physical motors directly via ``2postMirror.db``
+     (per-end Y / pitch / vertical) and the energy-change IOC (table
+     X). No composite axes, no soft motor.
 
-   Tracked as `xray-imaging/2bm-docs#171
-   <https://github.com/xray-imaging/2bm-docs/issues/171>`__ (fix
-   the ``M1Y`` mapping in the ``table.db`` substitution in
-   ``iocBoot/ioc2bma/st.cmd``).
+   **Path C was chosen** (operator-confirmed 2026-06-15): the
+   ``dbLoadRecords`` line for ``table.db`` was commented out in
+   ``iocBoot/ioc2bma/st.cmd``, so the ``2bma:table1`` record and
+   its ``.X / .Y / .Z / .AX / .AY / .AZ`` composite axes no longer
+   exist in CA. All operational motion at the mirror goes through
+   ``2postMirror.db`` (pitch / vertical) and the energy-change IOC
+   (table X for stripe-selector extension); ``2bma:m6`` (the Z
+   support) remains an addressable raw motor record but is not used
+   operationally.
 
 Double Multilayer Monochromator (DMM)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1186,10 +1186,15 @@ Hexapod
    suffixes ``-E1`` (incremental encoders), ``-PL4`` (ULTRA
    high-accuracy performance grade) and ``-TAS`` (tested and
    integrated as a system).
+:Serial number: ``486060-01``
 :Mounted on: Sample optical table
 :Carries: LaminographyPitch
-:Driven by: ``HexapodDrive`` (cora ``MotionController``
-   Asset; specific product line not yet confirmed on this page)
+:Driven by: ``HexapodDrive`` (cora ``MotionController`` Asset,
+   bound to Aerotech **Automation1-iXR3** drive, full ordering
+   code ``Automation1-iXR3-VL1-VB4-VB4-SB0CT222222-P1P1P1P1P1P1-CO-LC1MT1PSO6-SI0-TAS``,
+   S/N ``486125-01``, in a separate rack; operator-confirmed
+   2026-06-15. Earlier this page noted "specific product line not
+   yet confirmed"; this is the resolution.)
 :Degrees of freedom: X, Y, Z, A (θ\ :sub:`x`), B (θ\ :sub:`y`), C (θ\ :sub:`z`)
 :Travel:
    X 55 mm, Y 60 mm, Z 25 mm, A 15°, B 15°, C 30° (single-axis moves
@@ -1240,7 +1245,7 @@ Hexapod
    2-BM-B sample stack on the Vibraplane-isolated optical table.
    Visible from bottom to top: the Aerotech HEX300-230HL hexapod (six
    struts), the Kohzu SA16A-RM laminography tilt stage (centre), and
-   the Aerotech ABS250MP-M-AS air-bearing rotary at top.
+   the Aerotech ABRS-250MP-M-AS air-bearing rotary at top.
 
 LaminographyPitch
 -----------------
@@ -1276,13 +1281,18 @@ Rotary
 :Role: Sample rotation axis (theta)
 :Family: RotaryStage
 :Model:
-   Stage — Aerotech ABS250MP-M-AS air-bearing direct-drive rotary
-   (250 mm aperture, mid-precision class). Drive — Aerotech Ensemble
-   HLE10-40-A-MXH (HLe-series digital drive). The cora Device
-   identifier ``Rotary`` is a role-name per cora's #111 convention
-   (vendor / model lives in the bound Model, not the Asset name).
-   Earlier candidate names: ``Aerotech_ABRS_rotary``,
-   ``aerotech_abs250mp_m_as``.
+   Stage — Aerotech **ABRS-250MP-M-AS** air-bearing direct-drive
+   rotary (Aerotech ABRS series, 250 mm aperture, mid-precision
+   class). Drive — Aerotech Ensemble HLE10-40-A-MXH (HLe-series
+   digital drive). The cora Device identifier ``Rotary`` is a
+   role-name per cora's #111 convention (vendor / model lives in
+   the bound Model, not the Asset name). Earlier candidate names:
+   ``Aerotech_ABRS_rotary``, ``aerotech_abs250mp_m_as`` — the
+   second one was based on a then-incorrect ``ABS`` reading of the
+   hardware label; operator confirmation 2026-06-15 settles the
+   model on ABRS.
+:Serial number: ``146853-A-1-1-X``
+:Reference drawing: ``630C2125 REV (-)``
 :Mounted on: LaminographyPitch (via a fixed -10° wedge — see above)
 :Carries: SampleTop_X, SampleTop_Z
 :Driven by: ``RotaryDrive`` (cora ``MotionController`` Asset
@@ -1631,6 +1641,13 @@ the operator increases for phase-contrast imaging.)
 :Model: Aerotech **PRO225SL-1000** mechanical-bearing linear stage
    (SL precision class, 1000 mm travel; the longest member of the
    PRO225SL family). cora Model: ``aerotech_pro225sl_1000``.
+:Motor: Aerotech **BM250_UF**, 240 VAC AC servo motor, S/N
+   ``234848-07``. This is the motor inside the PRO225SL stage that
+   drives the ball screw (the stage's product name is PRO225SL-1000;
+   the motor's vendor part number is the BM250 series). The
+   ``PropagationDistanceDrive`` Aerotech controller is the
+   electronics box that runs this motor; see that Asset for the
+   drive's own model + serial.
 :Mounted on: Detector optical table
 :Carries: Optique Peter MICRX080 microscope
 :Driven by: ``PropagationDistanceDrive`` (cora ``MotionController``


### PR DESCRIPTION
## Additional commits

Two follow-up commits from the same 2026-06-15 operator-confirmation session at 2-BM. Both land in `manual/item_020.rst`.

| Hash | Subject | Cora question / issue it answers |
|---|---|---|
| `c348855` | docs(item_020): confirm rotary is ABRS-250MP-M-AS; add stage S/Ns + HexapodDrive Automation1-iXR3 + PropagationDistance motor (BM250_UF) | [vendor-catalog corrections (cora#156)](https://github.com/xmap/cora/issues/156); resolves HexapodDrive half of DRIVE-4 (Nice-to-have) |
| `2f35b78` | docs(item_020): drop 2bma:table1 virtual record (Path C); rewrite Mirror optical table block as per-motor history | resolves [xray-imaging/2bm-docs#171](https://github.com/xray-imaging/2bm-docs/issues/171) (M1Y=m3 IOC substitution error) |

## What these add

**`c348855`** — four operator-confirmed identifications:

- Rotary stage is an Aerotech **ABRS-250MP-M-AS** (Aerotech ABRS series). Prior docs (and CORA's `aerotech_abs250mp` Model row) had `ABS250MP-M-AS` — a long-standing typo, confirmed against the hardware label 2026-06-15. Added Rotary `:Serial number:` `146853-A-1-1-X` and `:Reference drawing:` `630C2125 REV (-)`.
- Hexapod stage `:Serial number:` `486060-01`.
- HexapodDrive is an Aerotech **Automation1-iXR3** (full ordering code `Automation1-iXR3-VL1-VB4-VB4-SB0CT222222-P1P1P1P1P1P1-CO-LC1MT1PSO6-SI0-TAS`, S/N `486125-01`, separate rack). Replaces the prior "specific product line not yet confirmed" hedge and resolves the HexapodDrive half of cora's DRIVE-4 Nice-to-have.
- PropagationDistance gains a `:Motor:` field naming the **`BM250_UF`** 240 VAC AC servo motor inside the PRO225SL-1000 stage (S/N `234848-07`). Three distinct identity layers (stage / motor / drive electronics) now visible on the page.

The CORA-side companion issue [cora#156](https://github.com/xmap/cora/issues/156) tracks the matching `aerotech_abs250mp` → `aerotech_abrs250mp` and `aerotech_hexapod_drive_unknown_pn` → `aerotech_automation1_ixr3` Model renames in `cora-doga/docs/deployments/2-bm/assets.md`, plus the Asset-level Settings / `alternate_identifiers` updates.

**`2f35b78`** — resolves the M1Y=m3 substitution issue (xray-imaging/2bm-docs#171). Operator chose **Path C**: comment out the `dbLoadRecords` for `2bma:table1` in `iocBoot/ioc2bma/st.cmd` entirely. The composite axes (`2bma:table1.X / .Y / .Z / .AX / .AY / .AZ`) no longer exist in CA; all operational motion at the mirror goes through `2postMirror.db` (per-end Y / pitch / vertical) and the energy-change IOC (table X for stripe-selector extension). No client code at 2-BM relied on the com
posite record, so the removal is clean.

Doc-side changes from this commit:

- Y3-30 Mirror `:Mounted on:` field rewritten — no longer cites `2bma:table1`; now describes the six physical motors and their two abstraction layers.
- `:MEDM screens:` field drops `table_full.adl` from the operational list (the screen is now non-functional at runtime).
- Mirror optical table block fully restructured: opening prose explains the virtual record is gone, new per-motor role table (one row per `2bma:m1`..`2bma:m6`, with `2bma:m3` clearly named as the in-vacuum X stripe selector, NOT a table support), figure caption updated to "historical screenshot", and the big `.. warning::` becomes a `.. note::` titled "History — `2bma:table1` virtual record removed 2026-06-15" that records what the substitution was, why it was wrong, the three resolution
 paths (A: soft motor, B: ASRPmirrorTable, C: drop the record), and why Path C was chosen.

## Updated PR test plan items

In addition to the original test-plan items:

- [ ] Rendered Y3-30 Mirror block: the `:Mounted on:` and `:MEDM screens:` fields render with the new wording; `:Serial number:` and `:Reference drawing:` fields render for the Rotary block; Hexapod has its `:Serial number:` row; PropagationDistance has its `:Motor:` row.
- [ ] Rendered Mirror optical table block: per-motor role simple-table fits column widths; the historical figure caption renders; the `.. note::` "History" block renders with the three-paths bullet list.
- [ ] Spot-check: no broken anchors. Anchors referenced by the cora-side tickets (`#y3-30-mirror`, `#rotary`, `#hexapod`, `#propagationdistance`) still resolve.

## Cross-references added by these commits

- [cora#156](https://github.com/xmap/cora/issues/156) — vendor catalog + Asset Settings updates from this operator session.
- [xray-imaging/2bm-docs#171](https://github.com/xray-imaging/2bm-docs/issues/171) — M1Y=m3 substitution error. **Now resolved via Path C in `2f35b78`; the issue can be closed with a "resolved via Path C, see commit `2f35b78`" comment.**
