### PR TITLE
docs: 2-BM cora-deployment Q&A pass (cora#246 through #265): post-APS-U inventory adoption, per-energy tables, mode + mirror documentation, two new procedure stubs

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1106,12 +1106,35 @@ Coded aperture (Jena NV200D piezo)
 :z position: ~51,300 mm (between the B-station Slits at 50,500 mm
    and the sample stack; just downstream of the last Be window
    before 2-BM-B)
-:Hardware: Piezosystem Jena **NV200D/NET** controller driving two
-   piezo axes (X and Y) on the coded-aperture flexure stage. Stroke
-   per axis ~100 µm (per :doc:`../ops/item_028`). NOT the NV100D
-   (which lacks the external trigger mode required for tomoscan
-   fly-scan integration and is therefore not used at 2-BM in any
-   operational procedure today).
+:Hardware (controller): Piezosystem Jena **NV200D/NET** controller
+   driving two piezo axes (X and Y). Vendor datasheet:
+   `NV200D-Datasheet.pdf
+   <https://www.piezosystem.com/wp-content/uploads/2023/07/NV200D-Datasheet.pdf>`__.
+   NOT the NV100D (which lacks the external trigger mode required
+   for tomoscan fly-scan integration and is therefore not used at
+   2-BM in any operational procedure today; see :doc:`../ops/item_027`
+   for the NV100D historical / decommissioned reference).
+:Hardware (actuator / XY flexure stage): Piezosystem Jena
+   **nanoSXY 120 CAP**, part number **T-223-06D** (the "D" suffix
+   denotes the digital interface variant). Drawing: `nanoSXY-120-CAP
+   <https://www.piezosystem.com/wp-content/uploads/2022/04/nanoSXY-120-CAP-Part-Drawing.pdf>`__
+   (rev.01, Feb 2019). Key dimensions:
+
+   ===========================  ==============
+   Property                     Value
+   ===========================  ==============
+   Travel per axis (nominal)    120 µm
+   Travel per axis (closed-loop, per :doc:`../ops/item_028`)  100 µm
+   Clear aperture               Ø 12.5 mm (centred)
+   Outer footprint              82 × 79 × 30 mm
+   Mounting                     4× M3 tapped + 4× Ø3 G7 reamed dowel holes (symmetric, on both sides); 32 mm / 54 mm / 60 mm hole-pattern centres
+   Standard cable length        1600 mm (voltage + sensor cables)
+   Feedback                     Capacitive (the ``CAP`` in the model)
+   ===========================  ==============
+
+   The clear aperture is what the coded-aperture mask itself is
+   mounted into; the X / Y piezo motion moves the mask within the
+   beam.
 :IOC: ``JenaNV200D`` (running on ``arcturus``)
 :Operational reference: :doc:`../ops/item_028` covers IOC startup,
    network configuration, caQtDM screens, FPGA trigger integration,

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -891,15 +891,29 @@ only two configurations selected by mode:
      - Downstream tank Y — in-beam vs retracted
 
 The X pair (``m25`` / ``m28``) is the same lateral position in both
-modes — they are **not** the multilayer stripe selector (the
-multilayer-stripe / pink-mode selection is on the Mirror, see
-``m1_horizontal`` (``2bma:m3``) in the Mirror M1 block). The three Y
-motors swing the DMM tank into or out of the beam at mode switch.
+modes — they are **not** the per-energy stripe selector. The
+per-energy mirror-stripe selection is on the Mirror M1 (see
+``m1_horizontal`` (``2bma:m3``) in the M1 block). The three Y motors
+swing the DMM tank into or out of the beam at mode switch.
 
 The IOC re-asserts these values on every energy change (they're in
 the `energy_move_*` set in ``energy2bm.json``), but interpolation
 between the two constant values per axis is degenerate — the
 result is the constant. This answers cora ENERGY-5.
+
+**DMM substrate carries two multilayer stripes** (full specs in
+:doc:`../ops/item_021`: 13.8 Å and 24 Å multilayer periods, 4 mm
+apart laterally, 140 x 44 mm² each, W-B₄C on Si). Across all six
+calibrated Mono energies, applying Bragg's law (``λ = 2d sin θ``) to
+the saved Bragg-arm angles yields ``d ≈ 24 Å`` to within ~5%, with no
+values near 13.8 Å — so the **24 Å stripe is the currently active
+one** at 2-BM. The 13.8 Å stripe has never been calibrated into
+``energy2bm.json``; switching to it would be a 4 mm lateral
+substrate move (the candidate axis is ``m25`` or ``m28``, since the
+substrate geometry matches the 4 mm stripe spacing, but the actual
+mapping needs operator confirmation) plus a separate Mono-mode
+recalibration of the Bragg arms and ``M2 Y`` for the new stripe.
+This answers cora ENERGY-6.
 
 **Per-energy saved positions (energy-tracking subset).** The energy-
 change IOC drives three of the DMM motors per energy: the two Bragg

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -675,13 +675,78 @@ laterally with an in-vacuum X stage:
 Selector motor: ``2bma:m3``. See the ops page above for the per-
 stripe expected-flux curve (``mirror_multilayer_coating.png``).
 
+**Stripe-to-position map** (inferred from the live ``energy2bm.json``
+``store_0`` table cross-checked against the Bragg resonance
+``λ = 2d sin θ`` at the operational pink-mode mirror angle
+``m1angl = 2.615 mrad``; operator confirmation of the assignments
+is pending):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 8 18 22 22 30
+
+   * - Stripe
+     - ``2bma:m3`` [mm]
+     - Table X (``m1mox`` /
+       ``m1m2x``) [mm]
+     - Calibrated Pink energy
+     - Bragg-calc resonance (or cutoff for Pt)
+   * - **a** Pt
+     - 1.0 (Mono)
+       3.039 (Pink 30 keV)
+     - 8.0 / 8.0
+     - All 6 Mono energies (held);
+       Pink 30 keV
+     - Pt critical-angle cutoff at ``θ = 2.615 mrad`` is
+       ≈ 21 keV; broadband below cutoff
+   * - **b**
+     - 13.0
+     - 10.0 / 10.0
+     - Pink 40 keV
+     - 36 keV (slight detuning from 40 keV)
+   * - **c**
+     - 39.0
+     - 10.0 / 10.0
+     - Pink 50 keV
+     - 49.8 keV (clean match)
+   * - **d**
+     - 49.0 (requires coordinated
+       table-X move)
+     - 29.0 / 29.0
+     - Pink 60 keV
+     - 60.3 keV (clean match)
+
+In **Mono mode** (all 6 calibrated energies 13.374 → 25.584 keV)
+``m3`` is **held at 1.0 mm** — stripe **a** (Pt) — with table X
+at 8.0 mm and mirror angle at 2.615 mrad. The DMM downstream does
+the per-energy monochromatic selection; the mirror just deflects
+the pink beam onto the DMM at a fixed geometry.
+
+In **Pink mode** (4 calibrated energies 30 → 60 keV) ``m3`` is
+**swept per energy**, walking up the substrate from stripe **a** at
+30 keV through stripes **b** / **c** / **d** at 40 / 50 / 60 keV.
+Table X (``m1mox`` / ``m1m2x``, mapped onto ``2bma:m1`` and
+``2bma:m4``) is co-moved per energy to extend the substrate's
+useful X range; at 60 keV the table-X support jumps from 10.0 to
+29.0 mm to reach stripe **d**. Mirror angle stays constant at
+2.615 mrad across all Pink energies.
+
+The stripe selection is therefore **not freely operator-selectable
+at run time** — the calibration table determines which stripe sits
+in the beam at each (mode, energy) tuple, and the energy-change IOC
+loads the table value on every energy change. Switching to a
+different stripe means either calibrating a new energy at that
+stripe via ``energy add``, or manually overriding ``m3``
+(operationally rare).
+
 .. warning::
 
    ``2bma:m3`` does not have enough travel on its own to reach the
-   highest-energy stripe. Reaching that stripe requires a coordinated
-   move of ``m3`` together with the optical-table X stages below.
-   This coordination is encapsulated by the energy-change IOC; see
-   :ref:`composite-iocs`.
+   highest-energy stripe (**d**). Reaching that stripe requires a
+   coordinated move of ``m3`` together with the optical-table X
+   stages (table X jumps from 10.0 to 29.0 mm at Pink 60 keV per the
+   table above). This coordination is encapsulated by the
+   energy-change IOC; see :ref:`composite-iocs`.
 
 **Mirror optical table.** The mirror sub-assembly sits on a
 multi-motor optical table whose six physical motors live on the

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1309,10 +1309,37 @@ Rotary
    distribution to the ML card. Bound cora Model:
    ``aerotech_ensemble`` (currently — see [cora#156] for the
    pending rename to a Model handle matching the actual P/N.))
-:Travel: -360 deg to +360 deg
-:Max speed: 720 deg/s
-:Encoder resolution: 0.0001 deg
+:Travel: 360° continuous (per datasheet); the 2-BM operational
+   software limits are configured at ``2bmb:m102.LLM = -360 deg``,
+   ``.HLM = +360 deg``.
+:Max speed (datasheet): 500 rpm (= 3000 deg/s). 2-BM operational
+   profile uses much lower speeds (the 720 deg/s value previously
+   listed here was an operational soft limit, not the stage maximum;
+   re-derive from the application speed profile rather than the
+   stage rating).
+:Encoder: 11,840 lines/rev fundamental (per datasheet). With
+   Aerotech's standard interpolation the addressable resolution is
+   sub-microradian, corresponding to roughly 0.0001 deg per step at
+   the application layer.
+:Accuracy: ±2 arc sec (per datasheet)
+:Repeatability (bidirectional): <1 arc sec (per datasheet)
 :Homing offset: 0 deg
+:Dimensions: 250 mm wide × 100 mm high; 228.1 mm tabletop diameter;
+   35 mm clear aperture (per datasheet — note: the "250" in
+   ``ABRS-250MP`` is the stage width, NOT the aperture, which earlier
+   revisions of this page conflated)
+:Bus voltage: 340 VDC (per datasheet)
+:Max load: 66 kg axial, 36 kg radial, 28 N·m tilt (per datasheet)
+:Air supply: 80 psig (5.5 bar) ± 10 psig; air consumption <56.6
+   SLPM (<2 SCFM); clean dry air at 0 °F dew point, 0.25 µm filter,
+   nitrogen at 99.9 % purity recommended (per datasheet)
+:Inertia (unloaded): 39,100 kg·mm² (per datasheet)
+:Total mass: 15.6 kg (per datasheet)
+:Material / finish: Aluminum, hardcoat (62 Rockwell hardness) (per datasheet)
+:Datasheet: https://de.aerotech.com/wp-content/uploads/2021/01/abrs.pdf
+   (Aerotech ABRS series rotary stages, covers ABRS150MP /
+   ABRS200MP / ABRS250MP / ABRS300MP; the 2-BM stage is the
+   ABRS250MP variant)
 :EPICS: ``2bmb:m102``
    (PV mapping from
    `tomoScanStream.substitutions

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -858,9 +858,12 @@ Flag (diagnostic phosphor)
    ``5 mm`` dial) -- out of the beam. In mono mode the flag is
    raised to block the M1-scattered halo while letting the
    monochromatic beam pass; the exact Y is energy-dependent.
-:Family: Diagnostic (no cora Family declared yet; this is the
-   first instance of a "viewable beam diagnostic" on the 2-BM
-   inventory).
+:Family: ``Screen`` (cora-confirmed).
+:cora Asset: ``DiagnosticFlag``, mounted on ``FrontEndDrive`` (the
+   front-end OMS VME58 #1). Operator-raised in Mono mode (Y
+   position is energy-dependent, see table below) and parked at
+   the lower limit in Pink mode. The energy-tracking Y curve is
+   the lookup-table data answering cora FLAG-1.
 :Mounted on: Own stand in 2-BM-A (floor-referenced).
 :Carries: phosphor-painted flag + visible camera (not modelled
    here; the camera is its own Asset).

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -148,10 +148,12 @@ Beam delivery
 =============
 
 The formal inventory of front-end and transport components, with
-positions, apertures, materials, and tolerances, is maintained as the
-**02-BM Beamline Component Reference Table** (APS_1404611):
-
-https://anl.box.com/s/afme9vpllerzzvsuzqiyxn7aukh7292j
+positions, apertures, materials, tolerances, and reference drawing
+numbers, is maintained as the **02-BM Beamline Component Reference
+Table** (APS_2191941, PDRC TN25-015, approved 04Aug2025, edited
+25Sept2025 following Commissioning with MLs and DMM motor-controller
+RSS removal). This is the post-APS-U revision and supersedes the
+earlier APS_1404611 (2013 pre-APS-U baseline).
 
 That document is the source of truth for positions and shielding;
 the summary below reproduces it in walking order (source to hutch) and
@@ -161,11 +163,12 @@ blocks for `cora <https://github.com/xmap/cora>`__.
 
 .. note::
 
-   The reference table was last formally updated for the 2013 Sector 02
-   Three-Year Safety Review and reflects the pre-APS-U layout. Post-
-   APS-U changes (mirror retrofit, source brightness, any added
-   components) need a separate reconciliation pass before this page is
-   considered final.
+   Several z positions in the per-component blocks further down this
+   page (Y3-30 Mirror, DMM crystals, P6-50 assembly) still carry the
+   pre-APS-U values from APS_1404611 and need a per-block reconciliation
+   pass against APS_2191941. The Be window stack (see "Be window stack"
+   below) and the P6-50 reference-drawing numbers are already updated
+   from APS_2191941.
 
 Coordinate convention (from the APS_1404611 reference table linked above):
 
@@ -234,9 +237,58 @@ Common position tolerances across all rows: dx = dy = 250 µm, dz = 5 mm.
 
 All four items are operational (have command surfaces) and are
 expanded in :ref:`operational components <operational-components>`.
-The P6-50 safety shutter (item 8c in the APS reference table) is also
-operational but gates the beam rather than conditioning it; it appears
-as its own block at the end of the operational-components section.
+The P6-50 safety shutter (row 10 in APS_2191941) is also operational
+but gates the beam rather than conditioning it; it appears as its own
+block at the end of the operational-components section.
+
+
+Be window stack
+---------------
+
+Three Be windows along the beam path, all OFHC-housed; total Be
+thickness **0.63 mm**. From APS_2191941 (post-APS-U), rows 5 / 8 / 9:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 6 22 22 12 12 26
+
+   * - #
+     - Component
+     - Reference drawing
+     - z [mm]
+     - Be thickness
+     - Aperture H x V [mm] and offset
+   * - 5
+     - W4-20 Be Window
+     - ``4105090804-200000``
+     - 28718
+     - 0.25 mm
+     - 120 x 15; on-centreline (x=0, y=0)
+   * - 8
+     - W4-60 Be Window
+     - ``4105090804-600000``
+     - 30804
+     - 0.13 mm
+     - 25 x 120; x = -7.4 mm (inboard), y = +22.3 mm (up)
+   * - 9
+     - Be Window (no separate label)
+     - ``4102020106-400000``
+     - 32417
+     - 0.25 mm
+     - 8.8 x 145; on-centreline (x=0), y = +31.0 mm (up)
+
+Position tolerances per row: dx = dy = 250 µm, dz = 5 mm. PSS [EPS]
+water flow rates: 1.5 LPM nominal, 1.0 LPM minimum (each window).
+Ref. z is the upstream face of the OFHC housing (ref convention 1 for
+W4-60 and the unlabelled Be window; ref convention 3 (upstream face of
+shielding material) for W4-20).
+
+.. note::
+
+   No standalone cora Asset for the Be windows; they are passive
+   beam-path elements with no command surface. Recorded here as
+   per-Run provenance / shielding inventory data. Answers cora
+   BEAM-2.
 
 
 .. _operational-components:
@@ -873,6 +925,12 @@ P6-50 Safety Shutter (B-shutter)
 :Material: W [21 mm]
 :Aperture: 60.0 × 44.5 mm
 :RSS tag: part of 02-BM-A-P-01 assembly
+:Reference drawing (shutter element): ``41050401-410003``
+:Reference drawing (full P6-50 assembly): ``41050401-500000``
+   (covers all four elements: white-beam stop ``41050401-300001``,
+   W collimator ``41050401-500001``, safety shutter
+   ``41050401-410003``, SS baffle ``41050401-500200``). Source:
+   APS_2191941 row 10. Answers cora BEAM-3.
 :EPICS prefix: ``S02BM-PSS:SBS``
 :Open command: ``S02BM-PSS:SBS:OpenEPICSC``
 :Close command: ``S02BM-PSS:SBS:CloseEPICSC``

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1656,10 +1656,99 @@ and ``m18`` are slots on the same OMS-VME58 card — cora Asset
 ``SampleStageDrive``. The hexapod motor ``2bmHXP:m3`` is one
 DoF of ``Hexapod``, driven by ``HexapodDrive``.
 
-Calibrated lens positions (mm, both cameras): Pos. 0 = -60.030,
-Pos. 1 = -0.8370, Pos. 2 = 58.64. Camera positions: Pos. 0 = 20,
-Pos. 1 = 15. Per-objective and per-camera fine focus and rotation
-offsets are held in the IOC's autosave file.
+**Calibrated lens positions are per-camera, not shared.** MCTOptics
+stores six turret positions (3 lenses × 2 cameras) so that the
+rotation axis stays at the same physical location when the operator
+swaps cameras. When ``LensSelect`` or ``CameraSelect`` changes, the
+IOC moves ``2bmb:m1`` to the position corresponding to the new
+(lens, camera) pair. PVs and operator-verified values
+(``caget`` 2026-06-19):
+
+==========  ==============================  ==============================
+Lens / mag  Camera 0 (mm)                   Camera 1 (mm)
+==========  ==============================  ==============================
+Lens 0 / 1.1×  ``2bm:MCTOptics:Camera0LensPos0`` = ``-59.8184``  ``2bm:MCTOptics:Camera1LensPos0`` = ``-60.3784``
+Lens 1 / 2×    ``2bm:MCTOptics:Camera0LensPos1`` = ``-0.5734``   ``2bm:MCTOptics:Camera1LensPos1`` = ``-0.9240``
+Lens 2 / 10×   ``2bm:MCTOptics:Camera0LensPos2`` = ``58.8707``   ``2bm:MCTOptics:Camera1LensPos2`` = ``59.2300``
+==========  ==============================  ==============================
+
+The per-camera offsets are ~0.4–0.6 mm and reflect the slightly
+different optical-path alignment between the two cameras on the
+dual-port (the folding-mirror selector at ``2bmb:m5`` swings the
+beam between the two camera arms). Operators rarely retune this
+alignment in routine operation; the per-camera position table is
+the mechanism that lets the IOC preserve the rotation-axis
+location across camera swaps when the alignment is fresh.
+
+Camera-selector positions (folding-mirror motor ``2bmb:m5``):
+Pos. 0 = 20 mm, Pos. 1 = 15 mm.
+
+**Per-(camera, lens) camera rotation offsets** follow the same
+lookup pattern as the turret positions above, on a different pair
+of motors: ``2bmb:m7`` (``CAM0_ROT``, camera 0 image-rotation
+alignment) and ``2bmb:m8`` (``CAM1_ROT``, camera 1). Same
+rationale: keep the rotation axis aligned to the image as the
+operator swaps lens or camera. Operator-verified values
+(``caget`` 2026-06-19):
+
+==========  ==============================  ==============================
+Lens / mag  Camera 0 rotation (``2bmb:m7``)  Camera 1 rotation (``2bmb:m8``)
+==========  ==============================  ==============================
+Lens 0 / 1.1×  ``2bm:MCTOptics:Camera0Lens0Rotation`` = ``0``        ``2bm:MCTOptics:Camera1Lens0Rotation`` = ``-0.781``
+Lens 1 / 2×    ``2bm:MCTOptics:Camera0Lens1Rotation`` = ``0.555``    ``2bm:MCTOptics:Camera1Lens1Rotation`` = ``-0.92``
+Lens 2 / 10×   ``2bm:MCTOptics:Camera0Lens2Rotation`` = ``0``        ``2bm:MCTOptics:Camera1Lens2Rotation`` = ``-1.06094``
+==========  ==============================  ==============================
+
+When the operator changes ``LensSelect`` or ``CameraSelect``, the
+IOC reads the matching ``Camera{N}Lens{M}Rotation`` PV and writes
+its value to ``2bmb:m7`` (if camera 0) or ``2bmb:m8`` (if camera 1).
+This is parallel to the turret-position lookup: same per-(camera,
+lens) pair, different motor.
+
+Unit follows the motor record's ``.EGU`` field for ``2bmb:m7`` /
+``2bmb:m8`` (typically degrees for a camera rotation stage; verify
+with ``caget 2bmb:m7.EGU``).
+
+**Per-(camera, lens) fine focus offsets** are the third 6-PV
+lookup family, this time on per-LENS focus motors:
+``LENS0_FOCUS`` / ``LENS1_FOCUS`` / ``LENS2_FOCUS`` =
+``2bmb:m2`` / ``2bmb:m3`` / ``2bmb:m4``. Structurally different
+from turret position (single motor ``m1``) and camera rotation
+(per-camera motor ``m7`` or ``m8``): focus has a different motor
+per lens, and the per-camera dimension is currently degenerate
+(Camera 0 and Camera 1 hold identical focus values for every
+lens in the present calibration). Operator-verified values
+(``caget`` 2026-06-19):
+
+==========  ==============================  ==============================
+Lens / mag  Camera 0 focus                  Camera 1 focus
+==========  ==============================  ==============================
+Lens 0 / 1.1× → ``2bmb:m2``  ``2bm:MCTOptics:Camera0Lens0Focus`` = ``-0.374848``  ``2bm:MCTOptics:Camera1Lens0Focus`` = ``-0.374848``
+Lens 1 / 2× → ``2bmb:m3``    ``2bm:MCTOptics:Camera0Lens1Focus`` = ``11.9161``    ``2bm:MCTOptics:Camera1Lens1Focus`` = ``11.9161``
+Lens 2 / 10× → ``2bmb:m4``   ``2bm:MCTOptics:Camera0Lens2Focus`` = ``0``          ``2bm:MCTOptics:Camera1Lens2Focus`` = ``0``
+==========  ==============================  ==============================
+
+When ``LensSelect`` changes to slot ``M`` and ``CameraSelect`` is
+``N``, the IOC writes ``Camera{N}Lens{M}Focus`` to ``2bmb:m{2+M}``.
+The per-camera dimension is supported by the IOC infrastructure
+but is not used in the current calibration (``Camera0Lens{M}Focus
+== Camera1Lens{M}Focus`` for every ``M``); the PVs exist for
+future per-camera focus calibration if needed.
+
+**Summary — three per-(camera, lens) MCTOptics lookups, applied
+coordinately on each LensSelect / CameraSelect change:**
+
+==========================  ==============================  ==============================  ==============================
+Lookup                      Motor(s)                        Value PVs                       Per-camera dimension today
+==========================  ==============================  ==============================  ==============================
+Turret position             ``2bmb:m1``                     ``Camera{N}LensPos{M}`` (6)     active (~0.4–0.6 mm offset)
+Camera rotation             ``2bmb:m7`` (cam0), ``m8`` (cam1)  ``Camera{N}Lens{M}Rotation`` (6)  active (some zero, some non-zero)
+Per-lens fine focus         ``2bmb:m2``/``m3``/``m4`` (per lens)  ``Camera{N}Lens{M}Focus`` (6)     degenerate (Cam0 == Cam1)
+==========================  ==============================  ==============================  ==============================
+
+18 calibration PVs in total. Whichever subset is non-degenerate
+in any given calibration, all 18 lookups exist and the IOC will
+apply each on LensSelect / CameraSelect changes.
 
 .. figure:: ../img/optique_peter_medm.png
    :width: 70%

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1991,6 +1991,12 @@ Optique Peter MICRX080 microscope
      Model ``Oryx ORX-10G-51S5M``. Sony IMX250 CMOS sensor,
      global shutter; 2448 × 2048, 3.45 µm pixel pitch; 162 fps
      at full resolution over 10GigE; 12-bit ADC. C-mount.
+     **Dual-role**: same physical camera (serial ``19173710``)
+     also serves as the vibration / flat-field stability
+     measurement camera at high frame rate (~99 fps, 1000-frame
+     HDF5 streams) per :doc:`../ops/item_021` and
+     :doc:`../ops/item_070`. There is **no separate high-speed
+     camera at 2-BM**. Answers cora VIB-1.
    - **FLIR Oryx 31MP** (camera 1, ``2bmSP2:`` areaDetector prefix).
      Model ``Oryx ORX-10G-310S9M``. Sony IMX367 CMOS sensor,
      global shutter; 6464 × 4852, 3.45 µm pixel pitch. C-mount.

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -477,8 +477,10 @@ Materials currently bound (read from the screen above):
    107.19 mm, ~1 mm beyond the ``None`` bind at 106.000 mm — i.e.,
    paddles are clear of the beam, but the motor cannot be commanded.
    Bindings (see table below) remain valid in the IOC and will
-   return to use when the motor is repaired or replaced; until then,
-   no downstream filter can be selected.
+   return to use when the motor is repaired or replaced. **Repair
+   is not expected in the near term**; the planning assumption for
+   the foreseeable future is that filter selection at 2-BM is via
+   the upstream paddle (m17) only.
 
    The **upstream paddle (`2bma:m17`)** is **fully operational** —
    paddles ``1 mm C``, ``150 µm Al``, ``600 µm Al``, ``1 mm Al``,

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1106,10 +1106,21 @@ Coded aperture (Jena NV200D piezo)
 :z position: ~51,300 mm (between the B-station Slits at 50,500 mm
    and the sample stack; just downstream of the last Be window
    before 2-BM-B)
-:Hardware (controller): Piezosystem Jena **NV200D/NET** controller
-   driving two piezo axes (X and Y). Vendor datasheet:
-   `NV200D-Datasheet.pdf
+:Hardware (controllers): **Two** Piezosystem Jena **NV200D/NET**
+   controllers, one per piezo axis (not a single dual-channel
+   controller). Each is Ethernet-attached and addressed via the
+   vendor's Telnet interface on port 23 ("NV200/D NET>" prompt):
+
+   =====  ====================  ====================
+   Axis   Controller IP         Vendor model
+   =====  ====================  ====================
+   X      ``10.54.113.126``     NV200D/NET
+   Y      ``10.54.113.125``     NV200D/NET
+   =====  ====================  ====================
+
+   Vendor datasheet: `NV200D-Datasheet.pdf
    <https://www.piezosystem.com/wp-content/uploads/2023/07/NV200D-Datasheet.pdf>`__.
+
    NOT the NV100D (which lacks the external trigger mode required
    for tomoscan fly-scan integration and is therefore not used at
    2-BM in any operational procedure today; see :doc:`../ops/item_027`
@@ -1138,8 +1149,40 @@ Coded aperture (Jena NV200D piezo)
 :IOC: ``JenaNV200D`` (running on ``arcturus``)
 :Operational reference: :doc:`../ops/item_028` covers IOC startup,
    network configuration, caQtDM screens, FPGA trigger integration,
-   and the triggered-step mode (``nv200_trigger_step_lib.py`` with
-   ``--linspace`` or ``--random``; standard list length 1024).
+   and the triggered-step mode.
+:Triggered-step programming procedure: Formal procedure page
+   :doc:`../procedures/item_013` (slug ``nv200_trigger_step``).
+   Implementation lives in the ``2bm-procedures`` repository at
+   `procedures/nv200_trigger_step.py
+   <https://github.com/decarlof/2bm-procedures/blob/main/procedures/nv200_trigger_step.py>`__
+   (official `nv200 Python library
+   <https://pypi.org/project/nv200/>`__-based; runs the per-axis
+   setup concurrently via ``asyncio``). Loads a 1024-position-max
+   waveform buffer into each controller via Telnet and arms the
+   FPGA-trigger-driven advance.
+
+   A second variant lives in the sandbox at
+   ``/home/beams/2BMB/conda/sandbox/nv200/nv200_trigger_step.py`` —
+   raw Telnet, no ``nv200`` library; documents the vendor's command
+   vocabulary directly (``gparb``, ``gsarb``, ``gearb``, ``goarb``,
+   ``gtarb``, ``gcarb``, ``trgfkt,2``, ``modsrc,3``, ``grun``,
+   ``gsave``/``gload``, ``meas``, ``posmin``/``posmax``, ``cl``).
+   Kept as a reference implementation of the protocol; not the
+   operationally-blessed script.
+
+   Defaults to ``n = 256`` positions per axis (max 1024) and takes
+   a ``--random`` flag for randomly-sampled positions (default is
+   evenly-spaced ``linspace``). After each generation the positions
+   are saved to ``positions_x.txt`` and ``positions_y.txt`` in the
+   current working directory. Current operational state (as of late
+   2026) uses ``--random`` for compressive-sensing dithered sampling
+   during tomography fly-scans.
+
+   Operational constraint: each controller only accepts **one
+   Telnet connection at a time**, so the EPICS IOC must be stopped
+   before running the script (and restarted afterwards). The
+   triggered-step state can optionally be persisted to EEPROM via
+   the script's ``save_to_eeprom()`` so it survives a power cycle.
 
 .. note::
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -848,6 +848,59 @@ their difference produces a Z-tilt around the beam axis. The second
 crystal is positioned relative to the first via the ``DSY`` (Y),
 ``M2 Z`` (along beam), and ``M2 Y`` motors.
 
+**Tank / alignment motors (energy-independent within mode).** The
+five DMM tank-positioning motors (``2bma:m25-m29``) are part of the
+energy-change coordinated move but do NOT vary per energy; they take
+only two configurations selected by mode:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 14 22 22 24
+
+   * - Motor
+     - PV
+     - Mono (in beam)
+     - Pink (out of beam)
+     - Role
+   * - ``dmm_usx``
+     - ``2bma:m25``
+     - 111.0
+     - 111.0 (same)
+     - Upstream tank lateral X — **fixed alignment** (NOT a stripe
+       selector; the value is identical in Mono and Pink)
+   * - ``dmm_usy_ob``
+     - ``2bma:m26``
+     - 0.0
+     - -10.0
+     - Upstream tank Y outboard — in-beam vs retracted
+   * - ``dmm_usy_ib``
+     - ``2bma:m27``
+     - 0.0
+     - -10.0
+     - Upstream tank Y inboard — in-beam vs retracted
+   * - ``dmm_dsx``
+     - ``2bma:m28``
+     - 104.0
+     - 104.0 (same)
+     - Downstream tank lateral X — **fixed alignment** (NOT a stripe
+       selector)
+   * - ``dmm_dsy``
+     - ``2bma:m29``
+     - 0.0
+     - -10.0
+     - Downstream tank Y — in-beam vs retracted
+
+The X pair (``m25`` / ``m28``) is the same lateral position in both
+modes — they are **not** the multilayer stripe selector (the
+multilayer-stripe / pink-mode selection is on the Mirror, see
+``m1_horizontal`` (``2bma:m3``) in the Mirror M1 block). The three Y
+motors swing the DMM tank into or out of the beam at mode switch.
+
+The IOC re-asserts these values on every energy change (they're in
+the `energy_move_*` set in ``energy2bm.json``), but interpolation
+between the two constant values per axis is degenerate — the
+result is the constant. This answers cora ENERGY-5.
+
 **Per-energy saved positions (energy-tracking subset).** The energy-
 change IOC drives three of the DMM motors per energy: the two Bragg
 arms (``2bma:m30`` / ``2bma:m31``) and the second-crystal vertical

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1083,6 +1083,54 @@ B-station Slits
      ``centre_and_close_slits`` (:doc:`../procedures/item_011`).
 
 
+Coded aperture (Jena NV200D piezo)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Role: Beam-shaping coded aperture mounted in the beam between the
+   B-station Slits and the sample. The aperture is stepped through
+   a list of (X, Y) piezo positions during a tomography fly-scan to
+   produce randomised / dithered sampling for compressive-sensing
+   imaging reconstructions.
+:Family: (Pending — neither Camera nor Stage in the traditional
+   sense; the mask itself is a beam-path optical element with its
+   own positioning piezo; cora's eventual Family choice for the
+   mask is a separate decision from the piezo controller below.)
+:cora Asset (piezo controller): ``CodedApertureFineDrive`` (proposed
+   name; ``SampleFineDrive`` was the earlier provisional placeholder
+   and is wrong — the device does not move the sample). Family:
+   ``MotionController``. Operator-confirmed 2026-06-19. The earlier
+   provisional ``OpticsFineDrive`` placeholder for the unused
+   NV100D (see :doc:`../ops/item_027`) should be retired since the
+   NV100D is not in operational use at 2-BM.
+:Hutch: 2-BM-B
+:z position: ~51,300 mm (between the B-station Slits at 50,500 mm
+   and the sample stack; just downstream of the last Be window
+   before 2-BM-B)
+:Hardware: Piezosystem Jena **NV200D/NET** controller driving two
+   piezo axes (X and Y) on the coded-aperture flexure stage. Stroke
+   per axis ~100 µm (per :doc:`../ops/item_028`). NOT the NV100D
+   (which lacks the external trigger mode required for tomoscan
+   fly-scan integration and is therefore not used at 2-BM in any
+   operational procedure today).
+:IOC: ``JenaNV200D`` (running on ``arcturus``)
+:Operational reference: :doc:`../ops/item_028` covers IOC startup,
+   network configuration, caQtDM screens, FPGA trigger integration,
+   and the triggered-step mode (``nv200_trigger_step_lib.py`` with
+   ``--linspace`` or ``--random``; standard list length 1024).
+
+.. note::
+
+   **Why this lives here (between B-station Slits and Sample
+   stack).** The coded aperture is a beam-path element upstream of
+   the sample, not part of the sample tower. Putting its description
+   in the z-ordered walk between B-station Slits (50,500 mm) and the
+   Sample stack section below matches the physical layout. The
+   piezo controller (``CodedApertureFineDrive``) is the
+   ``MotionController`` Asset that drives the aperture mask, but the
+   mask itself is a separate beam-path element — cora's eventual
+   Asset model needs both.
+
+
 Sample stack
 ============
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1104,6 +1104,65 @@ Pink-beam mode: flag at ``Y = 0 mm`` (user) -- same as the
    operating in
    pink mode means writing ``0 mm`` user to ``2bma:m44``.
 
+2-BM-A alignment camera (FLIR Oryx 5MP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Role: Beamline-alignment diagnostic camera that images the white,
+   pink, or monochromatic beam at the 2-BM-A end. Used during the
+   white-beam centring + mirror / DMM alignment procedure (see
+   :doc:`../ops/item_012` and :doc:`../procedures/item_015`).
+:Family: Camera (a second instance of the cora ``Camera`` Family;
+   the per-microscope detectors at 2-BM-B are the other instances).
+:cora Asset: proposed ``AStationAlignmentCamera`` (cora has not
+   chosen a handle yet; the role-name convention "Camera named by
+   what it images" would also work as ``WhiteBeamAlignmentCamera``).
+:Hutch: 2-BM-A.
+:Mounting: Permanently installed at 2-BM-A on a stand with a single
+   vertical (Y) motor for beam-finding. **Semi-permanent
+   diagnostic** — the camera is always in place, but the beam
+   only reaches it when the upstream vacuum chamber is opened and a
+   pipe section is physically removed. This is a multi-hour
+   operation done only **rarely** (annual / multi-year cadence,
+   typically for major realignment after a long shutdown or major
+   optics intervention). The setup is kept installed for
+   convenience because the disassembly / reassembly time is
+   nontrivial.
+:Camera model: FLIR Oryx 5MP (inferred from the IOC startup script
+   name ``2bmbOryx5MP``; same camera-family as the
+   :ref:`microscope-camera-0 <camera-0-2bmsp1>` at 2-BM-B but a
+   distinct physical unit). Operator confirmation of the exact
+   ``ORX-10G-51S5M`` model number is pending.
+:Vertical-stage motor: ``2bma:m21`` (single Y axis used for
+   beam-finding during alignment; positioned in the beam path by
+   the alignment procedure, returns to a parked Y between uses).
+:IOC: ``2bmbOryx5MP`` running on host **lyra** (a 2-BM-B
+   workstation per :doc:`../ops/item_017`; physically remote from
+   the camera in 2-BM-A but addresses it via the network). Start
+   sequence (per :doc:`../ops/item_012`)::
+
+     (base) 2bmb@lyra ~ $ 2bmbOryx5MP medm
+     (base) 2bmb@lyra ~ $ 2bmbOryx5MP run
+
+:EPICS prefix: TBD (not separately documented; accessible through
+   the IOC name above. Operator confirmation pending whether the
+   areaDetector prefix is ``2bmA:`` / ``2bma:`` / something else).
+:Live viewer: ImageJ with the EPICS_NTNDA plug-in is the standard
+   operator surface during alignment; ``ImageJ`` invoked from lyra.
+
+.. note::
+
+   **Why this is documented as a permanent inventory entry, not a
+   transient diagnostic.** The cora ALIGN-1 question explicitly
+   asks whether this is a standing diagnostic or a temporary
+   setup brought in only for alignment. The operationally correct
+   answer is **semi-permanent**: physically installed all the
+   time, but the beam only reaches it when an operator manually
+   breaks vacuum and removes a pipe. So it belongs in the cora
+   inventory as a registered ``Camera`` Asset (not a temporary /
+   transient fixture), with the understanding that its
+   operational-availability state is "deployed but not engaged"
+   most of the time. This answers cora ALIGN-1.
+
 P6-50 Safety Shutter (B-shutter)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -472,10 +472,20 @@ Materials currently bound (read from the screen above):
 
 .. warning::
 
-   Only the **downstream** paddle set is currently operational. The
-   upstream paddle materials listed above are bound in software but
-   the hardware is not in service; selecting them has no effect on the
-   beam.
+   **Downstream paddle (`2bma:m18`) motor is failed.** Operator-
+   reported 2026-06-19. The motor is currently parked at position
+   107.19 mm, ~1 mm beyond the ``None`` bind at 106.000 mm — i.e.,
+   paddles are clear of the beam, but the motor cannot be commanded.
+   Bindings (see table below) remain valid in the IOC and will
+   return to use when the motor is repaired or replaced; until then,
+   no downstream filter can be selected.
+
+   The **upstream paddle (`2bma:m17`)** is **fully operational** —
+   paddles ``1 mm C``, ``150 µm Al``, ``600 µm Al``, ``1 mm Al``,
+   and ``None`` are all selectable. Earlier revisions of this page
+   said upstream "hardware not in service"; that was incorrect and
+   has been removed. Filter selection at 2-BM today is therefore
+   available via the upstream paddle only, until m18 is repaired.
 
 .. figure:: ../img/filter_setup.png
    :width: 480px
@@ -528,9 +538,10 @@ downstream ``2bma:m18.VAL``.
      - LowLimit
      - 0.000
 
-Position units follow the motor record's ``.EGU`` field; the regular
-~25-26 spacing across the 0–106 range is consistent with a millimetre
-travel.
+Position units are **millimetres**, per ``caget 2bma:m18.EGU``
+(operator-verified 2026-06-19; PV returns ``mm``). The regular
+~25-26 mm spacing across the 0–106 mm range is the physical paddle
+pitch.
 
 Y3-30 Mirror
 ~~~~~~~~~~~~

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -242,6 +242,42 @@ but gates the beam rather than conditioning it; it appears as its own
 block at the end of the operational-components section.
 
 
+Front-end exit mask (M3-24)
+---------------------------
+
+First beam-defining aperture on the 2-BM beamline; passive,
+water-cooled, fixed in place. Defines the white-beam optical
+aperture that downstream optics see. From APS_2191941 row 1:
+
+:RSS tag: ``02-BM-A-F-01``
+:Reference drawing: ``4102020101-240000``
+:z position: **24020 mm** (= 24.020 m from the centre of the
+   storage-ring straight section; ref convention 1 = upstream
+   face of the OFHC copper block)
+:Optical aperture (H × V): **44.4 mm × 4.5 mm**
+:Material: OFHC copper
+:Position tolerance: dx = dy = 250 µm, dz = 5 mm
+:PSS [EPS] water flow rates: 1.5 LPM nominal, 1.0 LPM minimum
+:Source-current limit: 220 mA
+:Notes: Aperture centred on the standard bending-magnet centreline
+   (1.35 mrad inboard); the upstream optics table is rotated to
+   accommodate the storage-ring wall. Thermal analysis is in
+   APSU_2286907.
+
+.. note::
+
+   No cora Asset for the FE exit mask itself — it has no command
+   surface (passive, fixed aperture, no actuator). Cora's ``Mask``
+   descriptor stub (the placeholder cora opened for this question)
+   is the appropriate model: a registered inventory item with
+   physical / shielding parameters but no commandable axes.
+   Answers cora ALIGN-2.
+
+   Earlier 2bm-docs versions of :doc:`../ops/item_012` cited the
+   mask as "50 mm × 3 mm (H × V)" — that was an outdated pre-APS-U
+   value; the post-APS-U dimensions above are authoritative.
+
+
 Be window stack
 ---------------
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -852,7 +852,7 @@ crystal is positioned relative to the first via the ``DSY`` (Y),
 change IOC drives three of the DMM motors per energy: the two Bragg
 arms (``2bma:m30`` / ``2bma:m31``) and the second-crystal vertical
 (``2bma:m32``). Values are stored in
-`energy2bm.json <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+`energy2bm.json <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__
 under the ``store_0`` field of each motor; the IOC reads them on each
 energy change. Reproduced here as a snapshot (the JSON file is the
 authoritative source):
@@ -939,7 +939,7 @@ Flag (diagnostic phosphor)
 The energy-dependent flag positions used by mono-beam scans are
 defined in the ``energy`` package's lookup table
 (`energy2bm.json
-<https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__,
+<https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__,
 key ``energy_move_flag``):
 
 ==============  ===================  ==========================
@@ -968,7 +968,7 @@ Pink-beam mode: flag at ``Y = 0 mm`` (user) -- same as the
    :doc:`../procedures/item_002` (``detector_z_rail_alignment``).
    The energy-dependent target Y is read from the
    ``energy_move_flag`` field of `energy2bm.json
-   <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__;
+   <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__;
    operating in
    pink mode means writing ``0 mm`` user to ``2bma:m44``.
 
@@ -1143,7 +1143,7 @@ B-station Slits
 vertical pair (``2bma:m9`` / ``2bma:m10``) per energy to follow the
 DMM beam-walk; the horizontal pair (``2bma:m11`` / ``2bma:m12``) is
 NOT energy-tracked. Values from
-`energy2bm.json <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+`energy2bm.json <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__
 ``store_0``:
 
 .. list-table::
@@ -2325,7 +2325,7 @@ Energy-change IOC
 
 :Exposes: Higher-level energy-change command surface (PV / RPC TBD;
    consult ``energyApp/`` in the repository).
-:Repository: https://github.com/xray-imaging/energy.git
+:Repository: https://github.com/decarlof/energy.git
    (standard EPICS app layout — ``energyApp/``, ``iocBoot/``,
    ``configure/``, ``src/``).
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -848,6 +848,69 @@ their difference produces a Z-tilt around the beam axis. The second
 crystal is positioned relative to the first via the ``DSY`` (Y),
 ``M2 Z`` (along beam), and ``M2 Y`` motors.
 
+**Per-energy saved positions (energy-tracking subset).** The energy-
+change IOC drives three of the DMM motors per energy: the two Bragg
+arms (``2bma:m30`` / ``2bma:m31``) and the second-crystal vertical
+(``2bma:m32``). Values are stored in
+`energy2bm.json <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+under the ``store_0`` field of each motor; the IOC reads them on each
+energy change. Reproduced here as a snapshot (the JSON file is the
+authoritative source):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 22 22 22 16
+
+   * - Mode
+     - Energy [keV]
+     - ``dmm_us_arm`` (``2bma:m30``)
+     - ``dmm_ds_arm`` (``2bma:m31``)
+     - ``dmm_m2_y`` (``2bma:m32``)
+   * - Mono
+     - 13.374
+     - 1.131
+     - 1.133
+     - 25.1201075
+   * - Mono
+     - 13.574
+     - 1.081
+     - 1.083
+     - 24.3201075
+   * - Mono
+     - 18.000
+     - 0.822
+     - 0.824
+     - 18.820045
+   * - Mono
+     - 20.000
+     - 0.726
+     - 0.737
+     - 17.020045
+   * - Mono
+     - 25.000
+     - 0.57725
+     - 0.58825
+     - 14.220045
+   * - Mono
+     - 25.584
+     - 0.561
+     - 0.572
+     - 13.920045
+   * - Pink
+     - 30 / 40 / 50 / 60
+     - 0.740 (parked)
+     - 0.751 (parked)
+     - 17.020045 (parked)
+
+The Pink-mode values are constant across all four configured energies
+(30 / 40 / 50 / 60 keV) — the Bragg arms are simply retracted to a
+fixed park position and ``m2_y`` is held at the same value it had at
+the Mono 20 keV configuration. The other five DMM motors
+(``2bma:m25–m29``) also have ``store_0`` entries — in Pink the Y
+motors (``USY OB`` / ``USY IB`` / ``DSY``) are driven to ``-10`` mm
+to take the DMM out of beam — but those are not what cora's ENERGY-1
+question asks about. This table answers cora ENERGY-1.
+
 Flag (diagnostic phosphor)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1075,6 +1138,57 @@ B-station Slits
    ``b_slit_bot`` (= ``2bma:m10``) in the energy-change IOC; the
    vertical pair tracks the per-energy beam position in Mono mode.
    See :ref:`composite-iocs`.
+
+**Per-energy vertical positions.** The energy-change IOC drives the
+vertical pair (``2bma:m9`` / ``2bma:m10``) per energy to follow the
+DMM beam-walk; the horizontal pair (``2bma:m11`` / ``2bma:m12``) is
+NOT energy-tracked. Values from
+`energy2bm.json <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+``store_0``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 22 30 30
+
+   * - Mode
+     - Energy [keV]
+     - ``b_slit_top`` (``2bma:m9``)
+     - ``b_slit_bot`` (``2bma:m10``)
+   * - Mono
+     - 13.374
+     - 28.804575
+     - 8.804575
+   * - Mono
+     - 13.574
+     - 28.804575
+     - 8.804575
+   * - Mono
+     - 18.000
+     - 28.804575
+     - 8.804575
+   * - Mono
+     - 20.000
+     - 31.144575
+     - 11.144575
+   * - Mono
+     - 25.000
+     - 26.23
+     - 6.23
+   * - Mono
+     - 25.584
+     - 26.28
+     - 6.28
+   * - Pink
+     - 30 / 40 / 50 / 60
+     - 10.0 (wide open)
+     - -10.0 (wide open)
+
+Mono-mode top/bottom values track each other (top − bottom ≈ 20 mm
+across all six configured energies); the slit aperture stays roughly
+constant while the pair's centre tracks the beam-walk. Pink-mode is
+constant across all four energies (slits parked wide open at
++10 / -10 mm; no per-energy tracking because the DMM is bypassed).
+This table answers cora ENERGY-2.
 
 .. note::
 

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -1283,21 +1283,32 @@ Rotary
 :Model:
    Stage — Aerotech **ABRS-250MP-M-AS** air-bearing direct-drive
    rotary (Aerotech ABRS series, 250 mm aperture, mid-precision
-   class). Drive — Aerotech Ensemble HLE10-40-A-MXH (HLe-series
-   digital drive). The cora Device identifier ``Rotary`` is a
-   role-name per cora's #111 convention (vendor / model lives in
-   the bound Model, not the Asset name). Earlier candidate names:
-   ``Aerotech_ABRS_rotary``, ``aerotech_abs250mp_m_as`` — the
-   second one was based on a then-incorrect ``ABS`` reading of the
-   hardware label; operator confirmation 2026-06-15 settles the
-   model on ABRS.
+   class). Drive — Aerotech **ENSEMBLE ML 10-40-IO-MXH**
+   (Multi-Loop subseries, 10 A, 40 V bus, I/O option, MXH option;
+   operator-confirmed against the hardware label 2026-06-16).
+   The cora Device identifier ``Rotary`` is a role-name per cora's
+   #111 convention (vendor / model lives in the bound Model, not
+   the Asset name). Earlier candidate names: ``Aerotech_ABRS_rotary``,
+   ``aerotech_abs250mp_m_as`` — the second one was based on a
+   then-incorrect ``ABS`` reading of the hardware label; operator
+   confirmation 2026-06-15 settles the model on ABRS.
 :Serial number: ``146853-A-1-1-X``
 :Reference drawing: ``630C2125 REV (-)``
 :Mounted on: LaminographyPitch (via a fixed -10° wedge — see above)
 :Carries: SampleTop_X, SampleTop_Z
 :Driven by: ``RotaryDrive`` (cora ``MotionController`` Asset
-   wrapping the Aerotech Ensemble HLE10-40-A-MXH; bound Model
-   ``aerotech_ensemble``)
+   wrapping the **Aerotech ENSEMBLE ML 10-40-IO-MXH**, S/N
+   ``730792/1``, Aeronet-networked. Earlier this page named the
+   drive as Ensemble HLE10-40-A-MXH; operator confirmation
+   2026-06-16 corrects both the subseries (ML, not HLe) and the
+   option suffix (``-IO-`` was missing). The drive card is housed
+   in an Aerotech **TM3-A-20B VDC-20B VDC / NO SPLIT / PS24-1 /
+   C1ML-06 / C2ML-09 / US-115VAC** chassis, S/N ``160591-A-1-1``
+   (Order # ``730578``, built to dwg ``630D2079 REV-H``); the
+   chassis + PS24-1 supply provide DC bus and Aeronet
+   distribution to the ML card. Bound cora Model:
+   ``aerotech_ensemble`` (currently — see [cora#156] for the
+   pending rename to a Model handle matching the actual P/N.))
 :Travel: -360 deg to +360 deg
 :Max speed: 720 deg/s
 :Encoder resolution: 0.0001 deg
@@ -1651,9 +1662,16 @@ the operator increases for phase-contrast imaging.)
 :Mounted on: Detector optical table
 :Carries: Optique Peter MICRX080 microscope
 :Driven by: ``PropagationDistanceDrive`` (cora ``MotionController``
-   Asset wrapping the Aerotech drive that the ``2bmbAERO`` IOC
-   manages; was ``FocusDrive`` in cora #111, renamed to match the
-   stage it drives)
+   Asset wrapping the **Aerotech Ensemble HLe 10-40-A-IO-MXH**
+   (HLe subseries, 10 A, 40 V bus, ``-A-`` option, ``-IO-`` option,
+   MXH option; full P/N as printed on the label:
+   ``EnsembleHLe10-40-A-IO-MXH``), S/N ``228849-02``,
+   operator-confirmed against the hardware label 2026-06-16. This
+   resolves the prior "specific product line not yet confirmed"
+   placeholder and the cora ``aerotech_2bmbaero_drive_unknown_pn``
+   Model row. The drive is what the ``2bmbAERO`` IOC manages; the
+   Asset was ``FocusDrive`` in cora #111, renamed to match the
+   stage it drives.)
 :Travel: 1000 mm
 :Accuracy: ±18 µm (SL Standard; calibrated grade not offered above 500 mm)
 :Resolution: 0.1 µm (high-resolution feedback) / 1.0 µm

--- a/docs/source/ops/item_012.rst
+++ b/docs/source/ops/item_012.rst
@@ -5,7 +5,12 @@ Beamline alignment
 White beam
 ==========
 
-Center the source white beam on the 50 mm × 3 mm (H × V) fixed mask.
+Center the source white beam on the fixed M3-24 front-end exit mask
+(44.4 mm × 4.5 mm H × V optical aperture, OFHC copper, at
+``z = 24020 mm`` per APS_2191941 row 1; see
+:doc:`../manual/item_020`). Earlier versions of this page cited
+"50 mm × 3 mm" — that was an outdated pre-APS-U value; the post-
+APS-U mask dimensions are above.
 
 Start the detector in 2-BM-A::
 

--- a/docs/source/ops/item_021.rst
+++ b/docs/source/ops/item_021.rst
@@ -5,7 +5,7 @@ DMM
 ===
 
 2-BM has a double crystal multi-layer monochromator (DMM) to change energy.
-The beamline x-ray energy change is managed by the `energy cli <https://github.com/xray-imaging/energy>`_ python library.
+The beamline x-ray energy change is managed by the `energy cli <https://github.com/decarlof/energy>`_ python library.
 
 Login into 2bmb@arcturus then::
 
@@ -16,7 +16,7 @@ for help::
 
     energy -h
 
-More detailed instructions are here the `energy cli <https://github.com/xray-imaging/energy>`_
+More detailed instructions are here the `energy cli <https://github.com/decarlof/energy>`_
 
 Technical information about the DMM are available at the links below:
 

--- a/docs/source/ops/item_022.rst
+++ b/docs/source/ops/item_022.rst
@@ -151,11 +151,35 @@ Procedure
       print(f"Measured energy: {E_meas:.6f} keV")
       print(f"Offset from nominal: {offset_keV:.6f} keV")
 
-7. Adjust monochromator calibration
+7. Update the monochromator calibration
 
-   - Compare the calculated true energy to the nominal monochromator value
+   - Compare the measured true energy to the nominal monochromator value
      (e.g. 20 keV).
-   - Apply an energy-offset correction in the control software if required.
+   - Update the per-energy calibration table directly via the
+     ``energy`` CLI; there is no separate "offset" stored anywhere.
+     Two equivalent options, operator's choice:
+
+     - **Update the existing calibrated entry**: tweak the optics
+       (typically the DMM upstream / downstream arms and ``M2 Y``)
+       until the channel-cut rocking curve peaks at exactly the
+       nominal energy, then save the corrected motor positions ::
+
+           (base) 2bmb@arcturus $ energy add --energy 20 --mode Mono
+
+       This overwrites the existing ``20.000 keV`` row of
+       ``energy2bm.json`` ``store_0`` with the now-correct motor
+       positions. Recommended when the nominal energy is the
+       operationally-targeted value.
+
+     - **Save a new calibrated point at the measured value** ::
+
+           (base) 2bmb@arcturus $ energy add --energy 20.05 --mode Mono
+
+       This adds a fresh ``20.050 keV`` row to ``energy2bm.json``
+       without modifying ``20.000``. Recommended when the measured
+       value itself is what subsequent operation will target, or
+       when you want to densify the calibration table around a band
+       of interest.
 
 8. Verify calibration
 

--- a/docs/source/ops/item_028.rst
+++ b/docs/source/ops/item_028.rst
@@ -128,15 +128,31 @@ Install the required Python library::
 
   pip install nv200 numpy
 
-Run the script on a computer on the beamline's private subnet (e.g.
-``arcturus``)::
+The script lives in the ``2bm-procedures`` repository
+(`procedures/nv200_trigger_step.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/nv200_trigger_step.py>`__).
+Change to that directory before invoking it — the script writes
+``positions_x.txt`` / ``positions_y.txt`` to the current working
+directory and looks for no input files. Run on a computer on the
+beamline's private subnet (e.g. ``arcturus``)::
 
-  [2bmb@arcturus]$ python nv200_trigger_step_lib.py [--n N] [--random]
+  [2bmb@arcturus]$ cd <path-to-2bm-procedures>/procedures
+  [2bmb@arcturus]$ python nv200_trigger_step.py [--n N] [--random]
+
+(Replace ``<path-to-2bm-procedures>`` with wherever the
+`2bm-procedures <https://github.com/decarlof/2bm-procedures>`__
+repository is checked out — e.g.
+``~/conda/2bm-procedures-decarlof``.)
 
 Arguments:
 
 - ``--n N`` — number of positions to load (default: 256, max: 1024)
 - ``--random`` — use random positions instead of evenly spaced (linspace)
+
+See the procedure page :doc:`../procedures/item_013` for the formal
+procedure definition (preconditions, parameters, steps,
+postconditions, failure modes) that this operational walk-through
+implements.
 
 Example output::
 

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -68,6 +68,20 @@ Current procedures
   trigger for the rest of the session. Targets the two
   ``CodedApertureFineDrive_X`` / ``_Y`` Assets and the coded-
   aperture XY flexure stage on the cora side.
+- :doc:`procedures/item_014` —
+  ``energy_characterization`` (**STATUS: STUB**). cora-Procedure-
+  shaped abstraction over the channel-cut crystal energy-calibration
+  recipe. The operator mounts a removable Si channel-cut crystal
+  (``2d = 3.84 Å``, consistent with Si (220), 36 × 3 mm) on the
+  2-BM-B sample-rotation stage in place of the sample, runs a
+  rocking-curve scan around the calculated Bragg angle, fits the
+  peak, and computes the measured energy + offset from the DMM
+  nominal setting. Full operator-facing recipe at
+  :doc:`ops/item_022`; broader alignment context (where this fits
+  in the white → pink → mono workflow) at :doc:`ops/item_012`. The
+  formal 2bm-procedures script implementation is pending; this is
+  cora's ``energy_characterization`` Procedure target with the
+  channel-cut crystal as a removable-reference-standard Subject.
 
 
 Stub procedures

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -87,15 +87,17 @@ procedure is implemented.
   Satisfies ``energy_configured``. Two-path procedure: exact-match
   pre-calibrated energy uses the ``energy2bm.json`` ``store_0`` row
   directly; off-table energy uses linear interpolation between the
-  two bracketing calibrated energies (reference algorithm in the
-  older synApps ``support/energy`` package; the newer deployed
-  ``xray-imaging/energy`` does not yet implement it). Pending
-  operator validation of the linear-interp assumption per motor.
+  two bracketing calibrated energies. Both paths are already live
+  in the deployed ``decarlof/energy`` fork (a fork of
+  ``xray-imaging/energy`` reconciled periodically via PR;
+  deployment lives at ``/home/beams/2BMB/epics/synApps/support/energy/``).
+  The formal 2bm-procedures wrapper is pending; the operator will
+  validate the linear-interp assumption per motor when writing it.
 - :doc:`procedures/item_006` — ``set_flag_in``. Satisfies
   ``flag_in_beam``. (Flag is ``2bma:m44`` in
   :doc:`manual/item_020`; energy-dependent target Y from
   `energy2bm.json
-  <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__.)
+  <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__.)
 - :doc:`procedures/item_007` — ``open_b_shutter``. Satisfies
   ``b_shutter_open``.
 - :doc:`procedures/item_008` — ``set_b_slits``. Satisfies

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -78,10 +78,23 @@ Current procedures
   peak, and computes the measured energy + offset from the DMM
   nominal setting. Full operator-facing recipe at
   :doc:`ops/item_022`; broader alignment context (where this fits
-  in the white → pink → mono workflow) at :doc:`ops/item_012`. The
+  in the white → pink → mono workflow) at :doc:`ops/item_015`. The
   formal 2bm-procedures script implementation is pending; this is
   cora's ``energy_characterization`` Procedure target with the
   channel-cut crystal as a removable-reference-standard Subject.
+- :doc:`procedures/item_015` —
+  ``align_beamline`` (**STATUS: STUB**). cora-Procedure-shaped
+  abstraction over the three-phase beamline alignment workflow:
+  phase 1 white-beam centring (M1 / DMM dropped out), phase 2
+  pink-beam tuning (M1 at 2.618 mrad), phase 3 mono-beam DMM setup
+  (DMM Y stages + Bragg arms + ``M2 Y`` calibrated, target arm
+  angle 1.25° at energy nominal). Optionally chained with the
+  :doc:`procedures/item_014` channel-cut calibration as a final
+  step to verify absolute energy. Full operator-facing recipe with
+  screenshots at :doc:`ops/item_012`. Procedure granularity (one
+  Method with three phases vs three separate Methods) is a design
+  decision deferred to formal implementation. Natural cora
+  session-start Method for the 2-BM deployment.
 
 
 Stub procedures

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -84,7 +84,13 @@ procedure is implemented.
 - :doc:`procedures/item_004` — ``set_a_slits``. Satisfies
   ``a_slits_open``.
 - :doc:`procedures/item_005` — ``set_energy_to_preselect``.
-  Satisfies ``energy_configured``.
+  Satisfies ``energy_configured``. Two-path procedure: exact-match
+  pre-calibrated energy uses the ``energy2bm.json`` ``store_0`` row
+  directly; off-table energy uses linear interpolation between the
+  two bracketing calibrated energies (reference algorithm in the
+  older synApps ``support/energy`` package; the newer deployed
+  ``xray-imaging/energy`` does not yet implement it). Pending
+  operator validation of the linear-interp assumption per motor.
 - :doc:`procedures/item_006` — ``set_flag_in``. Satisfies
   ``flag_in_beam``. (Flag is ``2bma:m44`` in
   :doc:`manual/item_020`; energy-dependent target Y from

--- a/docs/source/procedures.rst
+++ b/docs/source/procedures.rst
@@ -55,6 +55,19 @@ Current procedures
   all blades restored to baseline. Open trigger to extend the
   per-station ``Slit`` Asset with per-blade calibration fields
   on the cora side.
+- :doc:`procedures/item_013` —
+  ``nv200_trigger_step``. Loads the per-axis coded-aperture
+  position list (default 256, max 1024 positions per axis) into
+  both Piezosystem Jena NV200D/NET controllers via Telnet and
+  arms them so each rising edge on TRG IN advances to the next
+  position in the buffer. ``--random`` selects compressive-sensing
+  dithered sampling (the current operational mode); ``--linspace``
+  (default) gives an evenly-spaced raster. Run once at session
+  setup or whenever the random list needs regenerating;
+  controllers then drive themselves frame-by-frame from the FPGA
+  trigger for the rest of the session. Targets the two
+  ``CodedApertureFineDrive_X`` / ``_Y`` Assets and the coded-
+  aperture XY flexure stage on the cora side.
 
 
 Stub procedures

--- a/docs/source/procedures/item_002.rst
+++ b/docs/source/procedures/item_002.rst
@@ -120,7 +120,7 @@ cora's dependency graph will be able to auto-resolve them.
      - ``2bma:m44`` (Flag Y) at the mode-appropriate position.
        Pink: ``0 mm`` user. Mono: per ``energy_move_flag`` lookup
        in `energy2bm.json
-       <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+       <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__
        (~12-23 mm depending on energy; ``0`` at 30+ keV). See
        item_020's Flag block.
      - :doc:`item_006` (``set_flag_in``)

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -75,9 +75,18 @@ Preconditions
 - :doc:`item_003` (``enable_beamline``).
 - :doc:`item_007` (``open_b_shutter``) — beam must reach the optics
   to verify the energy change.
-- A-shutter is closed for the duration of the move (the live
-  ``move.py::motors()`` auto-closes the front-end shutter before
-  the coordinated moves and re-opens it on completion).
+- **A-shutter handling is NOT automated by the energy change.** The
+  deployed ``move.py::motors()`` has both the close and re-open
+  calls explicitly commented out (the close-side log still prints
+  "closing A-shutter" misleadingly; the open-side log says
+  "opening shutter after energy change has been disabled"). The
+  A-shutter stays open continuously throughout an experimental
+  session per the operational practice documented in the A-shutter
+  block of :doc:`../manual/item_020` — closing and re-opening it
+  per energy change would create thermal transients in the
+  beamline optics. The formal procedure's precondition is simply
+  that the A-shutter is in whatever state the operator has chosen
+  (typically open); no per-move shutter sequencing.
 
 
 Parameters
@@ -189,8 +198,10 @@ Failure modes
 - **Calibrated list contains only one entry** → no interpolation
   possible; only Path A works (exact match required). Currently
   not an operational concern (Mono has 6, Pink has 4).
-- **Front-end shutter fails to close** before the moves → procedure
-  must abort before commanding the per-energy moves.
+- (Front-end shutter handling: not applicable — the deployed
+  ``move.py::motors()`` does not close or re-open the A-shutter
+  during the energy change, see Preconditions above. The A-shutter
+  stays in whatever state the operator left it in.)
 - **One or more motors fail to reach the commanded position**
   within timeout (``AllDoneA`` / ``AllDoneB`` never clears) →
   the energy mode PV is NOT updated and the procedure reports

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -6,8 +6,15 @@ Set energy to preselect
 
    **STATUS: STUB.** Placeholder for the procedure that satisfies
    the precondition ``energy_configured`` of :doc:`item_002`
-   (``detector_z_rail_alignment``). To be fleshed out as the
-   procedure is implemented.
+   (``detector_z_rail_alignment``) and is the natural target of
+   cora's eventual ``BeamEnergy`` Method surface. To be fleshed
+   out as the procedure is implemented in
+   `2bm-procedures <https://github.com/decarlof/2bm-procedures>`__.
+
+   The interpolation algorithm and the two-codebase situation
+   captured below are the **starting points** for the
+   implementation — the operator (DeCarlo) will validate and
+   refine both when writing the formal procedure.
 
 
 Name
@@ -19,26 +26,58 @@ Name
 Source
 ------
 
-Not yet implemented in this repository. Future location: `procedures/set_energy_to_preselect.py
+Not yet implemented in this repository. Future location:
+`procedures/set_energy_to_preselect.py
 <https://github.com/decarlof/2bm-procedures/blob/main/procedures/set_energy_to_preselect.py>`__
 in the `2bm-procedures
 <https://github.com/decarlof/2bm-procedures>`__ repository. Likely a
 thin wrapper around the `energy
 <https://github.com/xray-imaging/energy>`__ package, which already
-implements the coordinated DMM + mirror energy change.
+implements the coordinated DMM + mirror per-energy move.
+
+**Two divergent reference implementations exist on disk**; the formal
+procedure will choose / port from these:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 50 25
+
+   * - Codebase
+     - Path
+     - Interpolation?
+   * - Newer ``xray-imaging/energy`` (deployed)
+     - ``/home/beams8/USER2BMB/conda/energy-decarlof/src/energy/``
+       (= `xray-imaging/energy <https://github.com/xray-imaging/energy>`__)
+     - **No** — ``move.py::motors()`` does raw dict lookup
+       (``pos = pos_energy_select[energy][key]``); KeyError if
+       requested energy is not in ``energy2bm.json``.
+   * - Older synApps support
+     - ``/home/beams8/USER2BMB/epics/synApps/support/energy/src/energy/``
+     - **Yes** — linear interpolation in
+       ``util.py::interpolate()`` driven from
+       ``__main__.py::run_set()`` lines 63–106.
+
+The lookup table itself (`energy2bm.json
+<https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__,
+``store_0`` field) is the same in both codebases; only the
+position-resolution algorithm differs.
 
 
 Devices
 -------
 
 - :doc:`../manual/item_020`: **Mirror M1** and **DMM** — drives both
-  optics to the energy-dependent positions in a coordinated move.
-- The reference implementation lives in the ``energy`` package at
-  https://github.com/xray-imaging/energy. The mono-energy
-  lookup table is at
+  optics, plus the downstream tracking group (table3y, flag,
+  B-hutch slits, filter paddle) to the per-energy positions in a
+  coordinated move. The full driven-motor list is in the
+  `Composite IOCs section of item_020.rst
+  <https://docs2bm.readthedocs.io/en/latest/source/manual/item_020.html#composite-iocs>`__.
+- The mono-energy + Pink-energy lookup tables are at
   https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json
-  (used by :doc:`item_006` for the energy-dependent flag Y and by
-  :doc:`item_008` for the energy-dependent B-slit Y).
+  (used by :doc:`item_006` for the energy-dependent flag Y, by
+  :doc:`item_008` for the energy-dependent B-slit Y, and the
+  per-energy DMM-axis tables in the
+  :doc:`../manual/item_020` DMM block).
 
 
 Preconditions
@@ -47,6 +86,9 @@ Preconditions
 - :doc:`item_003` (``enable_beamline``).
 - :doc:`item_007` (``open_b_shutter``) — beam must reach the optics
   to verify the energy change.
+- A-shutter is closed for the duration of the move (see the older
+  synApps ``move.py::motors()`` which auto-closes / re-opens the
+  front-end shutter around the motor moves).
 
 
 Parameters
@@ -55,26 +97,136 @@ Parameters
 - ``energy_keV`` (number > 0) — target energy. Default for
   ``detector_z_rail_alignment``: TBD (whichever preselect the
   experiment is running on).
+- ``mode`` (``"Mono"`` | ``"Pink"``) — selects which lookup
+  branch of ``energy2bm.json`` to use. Mono has 6 calibrated
+  energies (13.374, 13.574, 18, 20, 25, 25.584 keV); Pink has 4
+  (30, 40, 50, 60 keV).
+- ``force`` (boolean, default false) — skip the interactive
+  "Confirm energy change?" prompt (operator-side safety gate in
+  the synApps reference implementation).
 
 
 Steps
 -----
 
-- TBD. Delegate to the ``energy`` package
-  (``energy.change_energy(keV)``); wait for mirror + DMM motors to
-  settle.
+**Two execution paths** depending on whether the requested energy is
+in the calibrated lookup table:
+
+**Path A — exact match (pre-calibrated energy)**
+
+1. Round requested ``energy_keV`` to 3 decimals.
+2. Look up positions in ``energy2bm.json`` for ``mode`` →
+   ``"{:.3f}".format(energy_keV)``.
+3. Apply each saved position to the driven motor (all keys matching
+   ``energy_move*`` and ``energy_pos*`` per the lookup row).
+4. Wait for ``AllDoneA`` AND ``AllDoneB`` flags to clear before
+   declaring the move complete.
+
+**Path B — interpolation (energy not in calibrated list)**
+
+Reference algorithm (older synApps ``__main__.py::run_set`` +
+``util.py::interpolate``):
+
+1. Reject if requested energy is **outside** the calibrated range
+   ``[min(calibrated), max(calibrated)]`` for the selected mode.
+2. Find the nearest calibrated energy
+   (``util.find_nearest(energies_flt, energy_select)``).
+3. Identify the bracketing pair ``(energy_low, energy_high)``
+   that straddles the requested value (one calibrated energy on
+   each side of the request).
+4. For each motor key in the bracketing pair's lookup row, **if the
+   key matches ``energy_move*``**: linearly interpolate ::
+
+      pos_new = pos_low + ((energy_select - energy_low)
+                           / (energy_high - energy_low))
+                          * (pos_high - pos_low)
+
+5. Keys matching ``energy_pos*`` are **not** interpolated — these
+   are static positions (e.g., filter-paddle slot index) that don't
+   vary continuously with energy.
+6. Apply the resulting interpolated dictionary the same way Path A
+   applies the lookup-row dictionary.
+
+The ``energy_move*`` vs ``energy_pos*`` distinction is encoded
+at the PV layer in the synApps reference: ``EnergyMoveXPVName``
+records the names of motors that are interpolated;
+``EnergyPosXPVName`` records the names of motors that are not.
+
+.. note::
+
+   **Pending operator validation.** The interpolation algorithm
+   above is the reference algorithm in the **older** synApps
+   ``energy`` package; the **newer** deployed
+   ``xray-imaging/energy`` package does not implement it (a
+   non-calibrated energy raises a ``KeyError`` in
+   ``move.py``). When this procedure is formally implemented in
+   ``2bm-procedures``, the operator will validate the linear-
+   interpolation assumption (motor-by-motor where appropriate;
+   some motors may need non-linear curves) and decide whether to
+   port the older algorithm or re-implement it directly.
+
+   Operationally, linear interpolation between adjacent calibrated
+   Mono points is plausible because the Bragg-angle / vertical-
+   offset / slit-walk curves change smoothly with energy. The
+   step-pattern visible in the B-slit centre trajectory (see the
+   ENERGY-2 ticket / docs) is an artefact of operator save
+   batching, not a physical non-linearity that interpolation
+   would need to respect.
 
 
 Postconditions
 --------------
 
 :Satisfies: ``energy_configured``
-:Predicate: Mirror M1 and DMM RBVs match the energy-dependent
-   lookup tables in the ``energy`` package (predicate is
-   energy-parameterised — needs current energy as input).
+:Predicate: Mirror M1 motors AND all driven DMM / downstream-tracking
+   motors AND ``flag`` AND B-slit Y pair AND filter-paddle slot
+   match either:
+
+   - the exact pre-calibrated row (Path A), or
+   - the linearly interpolated targets (Path B)
+
+   within per-motor position tolerance. The energy-mode PV
+   (``2bma:TomoScan:EnergyMode``) and the energy PV
+   (``2bma:TomoScan:Energy``) are updated to reflect the new state.
 
 
 Failure modes
 -------------
 
-- TBD.
+- **Energy outside calibrated range** (Path B) → error before any
+  motion is initiated.
+- **Calibrated list is empty or corrupt** → error before any motion.
+- **Calibrated list contains only one entry** → no interpolation
+  possible; only Path A works (exact match required).
+- **Front-end shutter fails to close** before the moves → procedure
+  must abort before commanding the per-energy moves.
+- **One or more motors fail to reach the commanded position**
+  within timeout (``AllDoneA`` / ``AllDoneB`` never clears) →
+  the energy mode PV is NOT updated and the procedure reports
+  partial completion.
+
+
+Operator walkthrough
+--------------------
+
+(TBD as the formal procedure is implemented in ``2bm-procedures``.)
+
+
+Notes
+-----
+
+- The ``energy2bm.json`` ``store_0`` field is the single source of
+  truth for calibrated positions across all energy-tracked axes
+  (DMM Bragg arms + ``M2 Y``, mirror stripe + table X in Pink mode,
+  diagnostic flag Y, B-station slit vertical pair, table3y, filter
+  paddle index). Adding a calibrated energy means editing this file,
+  not the IOC source or this procedure.
+- This procedure is the natural cora ``BeamEnergy`` Method target
+  — a single operator-facing "set energy to X keV" surface that
+  resolves into the ~15 coordinated motor moves catalogued in
+  the :doc:`../manual/item_020` Composite IOCs section.
+- The sandbox at ``/home/beams8/DECARLO/conda/sandbox/energy/``
+  has three one-off scripts (TomoScan-PV wrapper, enum-PV dispatcher,
+  Bragg-arm calibration scan) — useful as snippets when implementing
+  the formal procedure, but not part of either deployed energy
+  codebase.

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -11,10 +11,11 @@ Set energy to preselect
    out as the procedure is implemented in
    `2bm-procedures <https://github.com/decarlof/2bm-procedures>`__.
 
-   The interpolation algorithm and the two-codebase situation
-   captured below are the **starting points** for the
-   implementation — the operator (DeCarlo) will validate and
-   refine both when writing the formal procedure.
+   The two-path Steps below capture the algorithm already in the
+   deployed `decarlof/energy
+   <https://github.com/decarlof/energy>`__ package; the operator
+   (DeCarlo) will validate the linear-interp assumption per motor
+   when writing the formal procedure.
 
 
 Name
@@ -26,41 +27,30 @@ Name
 Source
 ------
 
-Not yet implemented in this repository. Future location:
-`procedures/set_energy_to_preselect.py
+Not yet implemented as its own script in this repository. Future
+location: `procedures/set_energy_to_preselect.py
 <https://github.com/decarlof/2bm-procedures/blob/main/procedures/set_energy_to_preselect.py>`__
 in the `2bm-procedures
-<https://github.com/decarlof/2bm-procedures>`__ repository. Likely a
-thin wrapper around the `energy
-<https://github.com/xray-imaging/energy>`__ package, which already
-implements the coordinated DMM + mirror per-energy move.
+<https://github.com/decarlof/2bm-procedures>`__ repository. Likely
+a thin wrapper around the live `decarlof/energy
+<https://github.com/decarlof/energy>`__ package, which already
+implements the coordinated DMM + mirror + downstream per-energy
+move.
 
-**Two divergent reference implementations exist on disk**; the formal
-procedure will choose / port from these:
+Deployed code base:
+``/home/beams/2BMB/epics/synApps/support/energy/`` (git remote
+`decarlof/energy <https://github.com/decarlof/energy>`__). That
+fork is reconciled with the
+`xray-imaging/energy <https://github.com/xray-imaging/energy>`__
+upstream periodically via pull request; cite the fork URL when
+referencing the live deployment.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 50 25
-
-   * - Codebase
-     - Path
-     - Interpolation?
-   * - Newer ``xray-imaging/energy`` (deployed)
-     - ``/home/beams8/USER2BMB/conda/energy-decarlof/src/energy/``
-       (= `xray-imaging/energy <https://github.com/xray-imaging/energy>`__)
-     - **No** — ``move.py::motors()`` does raw dict lookup
-       (``pos = pos_energy_select[energy][key]``); KeyError if
-       requested energy is not in ``energy2bm.json``.
-   * - Older synApps support
-     - ``/home/beams8/USER2BMB/epics/synApps/support/energy/src/energy/``
-     - **Yes** — linear interpolation in
-       ``util.py::interpolate()`` driven from
-       ``__main__.py::run_set()`` lines 63–106.
-
-The lookup table itself (`energy2bm.json
-<https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__,
-``store_0`` field) is the same in both codebases; only the
-position-resolution algorithm differs.
+The lookup table is at
+`src/energy/data/energy2bm.json
+<https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__
+(``store_0`` field per motor). The position-resolution algorithm is
+in ``src/energy/util.py::interpolate()`` driven from
+``src/energy/__main__.py::run_set()`` lines 63–106.
 
 
 Devices
@@ -72,11 +62,10 @@ Devices
   coordinated move. The full driven-motor list is in the
   `Composite IOCs section of item_020.rst
   <https://docs2bm.readthedocs.io/en/latest/source/manual/item_020.html#composite-iocs>`__.
-- The mono-energy + Pink-energy lookup tables are at
-  https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json
-  (used by :doc:`item_006` for the energy-dependent flag Y, by
-  :doc:`item_008` for the energy-dependent B-slit Y, and the
-  per-energy DMM-axis tables in the
+- The Mono + Pink lookup tables share the single ``energy2bm.json``
+  file linked above (used by :doc:`item_006` for the energy-dependent
+  flag Y, by :doc:`item_008` for the energy-dependent B-slit Y, and
+  by the per-energy DMM-axis tables in the
   :doc:`../manual/item_020` DMM block).
 
 
@@ -86,9 +75,9 @@ Preconditions
 - :doc:`item_003` (``enable_beamline``).
 - :doc:`item_007` (``open_b_shutter``) — beam must reach the optics
   to verify the energy change.
-- A-shutter is closed for the duration of the move (see the older
-  synApps ``move.py::motors()`` which auto-closes / re-opens the
-  front-end shutter around the motor moves).
+- A-shutter is closed for the duration of the move (the live
+  ``move.py::motors()`` auto-closes the front-end shutter before
+  the coordinated moves and re-opens it on completion).
 
 
 Parameters
@@ -98,34 +87,35 @@ Parameters
   ``detector_z_rail_alignment``: TBD (whichever preselect the
   experiment is running on).
 - ``mode`` (``"Mono"`` | ``"Pink"``) — selects which lookup
-  branch of ``energy2bm.json`` to use. Mono has 6 calibrated
-  energies (13.374, 13.574, 18, 20, 25, 25.584 keV); Pink has 4
-  (30, 40, 50, 60 keV).
+  branch of ``energy2bm.json`` to use. Live calibrated set: Mono
+  has 6 energies (13.374, 13.574, 18.000, 20.000, 25.000, 25.584
+  keV); Pink has 4 (30.000, 40.000, 50.000, 60.000 keV).
 - ``force`` (boolean, default false) — skip the interactive
   "Confirm energy change?" prompt (operator-side safety gate in
-  the synApps reference implementation).
+  the live implementation).
 
 
 Steps
 -----
 
 **Two execution paths** depending on whether the requested energy is
-in the calibrated lookup table:
+in the calibrated lookup table. Both are already implemented in
+``decarlof/energy``; this procedure wraps them.
 
 **Path A — exact match (pre-calibrated energy)**
 
 1. Round requested ``energy_keV`` to 3 decimals.
-2. Look up positions in ``energy2bm.json`` for ``mode`` →
-   ``"{:.3f}".format(energy_keV)``.
-3. Apply each saved position to the driven motor (all keys matching
-   ``energy_move*`` and ``energy_pos*`` per the lookup row).
+2. Look up positions in ``energy2bm.json`` under
+   ``mode`` → ``"{:.3f}".format(energy_keV)``.
+3. Apply each saved position to its motor — every key matching
+   ``energy_move*`` (interpolatable) and ``energy_pos*`` (static).
 4. Wait for ``AllDoneA`` AND ``AllDoneB`` flags to clear before
    declaring the move complete.
 
 **Path B — interpolation (energy not in calibrated list)**
 
-Reference algorithm (older synApps ``__main__.py::run_set`` +
-``util.py::interpolate``):
+Reference algorithm (live ``util.py::interpolate()`` +
+``__main__.py::run_set()`` lines 63–106):
 
 1. Reject if requested energy is **outside** the calibrated range
    ``[min(calibrated), max(calibrated)]`` for the selected mode.
@@ -135,43 +125,40 @@ Reference algorithm (older synApps ``__main__.py::run_set`` +
    that straddles the requested value (one calibrated energy on
    each side of the request).
 4. For each motor key in the bracketing pair's lookup row, **if the
-   key matches ``energy_move*``**: linearly interpolate ::
+   key matches** ``energy_move*``: linearly interpolate ::
 
       pos_new = pos_low + ((energy_select - energy_low)
                            / (energy_high - energy_low))
                           * (pos_high - pos_low)
 
 5. Keys matching ``energy_pos*`` are **not** interpolated — these
-   are static positions (e.g., filter-paddle slot index) that don't
-   vary continuously with energy.
+   are static positions (currently just ``fltr1select``, the
+   downstream filter-paddle slot index) that don't vary
+   continuously with energy.
 6. Apply the resulting interpolated dictionary the same way Path A
    applies the lookup-row dictionary.
 
-The ``energy_move*`` vs ``energy_pos*`` distinction is encoded
-at the PV layer in the synApps reference: ``EnergyMoveXPVName``
-records the names of motors that are interpolated;
-``EnergyPosXPVName`` records the names of motors that are not.
+The ``energy_move*`` vs ``energy_pos*`` distinction is encoded in
+the JSON key names and honoured by both ``util.py::interpolate()``
+(which filters on ``'energy_move' in key``) and ``move.py::motors()``
+(which accepts both prefixes for the actual move).
 
 .. note::
 
-   **Pending operator validation.** The interpolation algorithm
-   above is the reference algorithm in the **older** synApps
-   ``energy`` package; the **newer** deployed
-   ``xray-imaging/energy`` package does not implement it (a
-   non-calibrated energy raises a ``KeyError`` in
-   ``move.py``). When this procedure is formally implemented in
-   ``2bm-procedures``, the operator will validate the linear-
-   interpolation assumption (motor-by-motor where appropriate;
-   some motors may need non-linear curves) and decide whether to
-   port the older algorithm or re-implement it directly.
+   **Pending operator validation.** Linear interpolation is the
+   algorithm already deployed for off-table energies. The operator
+   will validate the linear assumption **motor-by-motor** when
+   writing the formal procedure in ``2bm-procedures`` — most
+   energy-tracked axes change smoothly with energy and linear is a
+   good first approximation, but some may need non-linear curves
+   (e.g., if the Bragg-angle parametrisation introduces a
+   trigonometric non-linearity that's visible at the operational
+   precision).
 
-   Operationally, linear interpolation between adjacent calibrated
-   Mono points is plausible because the Bragg-angle / vertical-
-   offset / slit-walk curves change smoothly with energy. The
-   step-pattern visible in the B-slit centre trajectory (see the
-   ENERGY-2 ticket / docs) is an artefact of operator save
-   batching, not a physical non-linearity that interpolation
-   would need to respect.
+   The step-pattern visible in the B-slit centre trajectory (see
+   the docs ENERGY-2 table) is an artefact of operator save batching
+   rather than a physical non-linearity that interpolation would
+   need to respect.
 
 
 Postconditions
@@ -193,11 +180,15 @@ Postconditions
 Failure modes
 -------------
 
-- **Energy outside calibrated range** (Path B) → error before any
-  motion is initiated.
-- **Calibrated list is empty or corrupt** → error before any motion.
+- **Energy outside calibrated range** (Path B) → live code logs
+  ``Error: energy selected ... is outside the calibrated range
+  [min, max]`` and aborts before any motion.
+- **Calibrated list is empty or corrupt** → live code logs
+  ``Pre-calibrated energies file ... is missing or corrupted``
+  and aborts.
 - **Calibrated list contains only one entry** → no interpolation
-  possible; only Path A works (exact match required).
+  possible; only Path A works (exact match required). Currently
+  not an operational concern (Mono has 6, Pink has 4).
 - **Front-end shutter fails to close** before the moves → procedure
   must abort before commanding the per-energy moves.
 - **One or more motors fail to reach the commanded position**
@@ -209,7 +200,17 @@ Failure modes
 Operator walkthrough
 --------------------
 
-(TBD as the formal procedure is implemented in ``2bm-procedures``.)
+Live CLI invocation (the formal procedure will wrap this):
+
+::
+
+   [2bmb@arcturus]$ energy set --mode Mono --energy 20.0
+
+(or ``--mode Pink``). The CLI handles Path A vs Path B internally
+based on whether the energy is in the calibrated list. The
+``--force`` flag skips the interactive Y/N prompt.
+
+Detailed CLI usage is in :doc:`../ops/item_021`.
 
 
 Notes
@@ -219,8 +220,14 @@ Notes
   truth for calibrated positions across all energy-tracked axes
   (DMM Bragg arms + ``M2 Y``, mirror stripe + table X in Pink mode,
   diagnostic flag Y, B-station slit vertical pair, table3y, filter
-  paddle index). Adding a calibrated energy means editing this file,
-  not the IOC source or this procedure.
+  paddle index, plus the ``m1angl`` / ``m1avg`` mirror geometry
+  setpoints). Adding a calibrated energy means editing this file
+  (or using ``energy add --energy N``), not the IOC source or
+  this procedure.
+- The deployed package is the user's fork (``decarlof/energy``)
+  reconciled with ``xray-imaging/energy`` upstream periodically via
+  PR. The live JSON ``store_0`` values may temporarily lag what
+  ends up on the xray-imaging main branch (and vice versa).
 - This procedure is the natural cora ``BeamEnergy`` Method target
   — a single operator-facing "set energy to X keV" surface that
   resolves into the ~15 coordinated motor moves catalogued in
@@ -228,5 +235,4 @@ Notes
 - The sandbox at ``/home/beams8/DECARLO/conda/sandbox/energy/``
   has three one-off scripts (TomoScan-PV wrapper, enum-PV dispatcher,
   Bragg-arm calibration scan) — useful as snippets when implementing
-  the formal procedure, but not part of either deployed energy
-  codebase.
+  the formal procedure, but not part of the deployment.

--- a/docs/source/procedures/item_005.rst
+++ b/docs/source/procedures/item_005.rst
@@ -75,18 +75,39 @@ Preconditions
 - :doc:`item_003` (``enable_beamline``).
 - :doc:`item_007` (``open_b_shutter``) — beam must reach the optics
   to verify the energy change.
-- **A-shutter handling is NOT automated by the energy change.** The
-  deployed ``move.py::motors()`` has both the close and re-open
-  calls explicitly commented out (the close-side log still prints
-  "closing A-shutter" misleadingly; the open-side log says
-  "opening shutter after energy change has been disabled"). The
-  A-shutter stays open continuously throughout an experimental
-  session per the operational practice documented in the A-shutter
-  block of :doc:`../manual/item_020` — closing and re-opening it
-  per energy change would create thermal transients in the
-  beamline optics. The formal procedure's precondition is simply
-  that the A-shutter is in whatever state the operator has chosen
-  (typically open); no per-move shutter sequencing.
+- **A-shutter handling is operator-managed** (current state =
+  temporary XANES-friendly patch; intended permanent behaviour is
+  conditional close, see below).
+
+  - The deployed ``move.py::motors()`` has both the close and
+    re-open calls **explicitly commented out** (the close-side log
+    still prints "closing A-shutter" misleadingly; the open-side
+    log says "opening shutter after energy change has been
+    disabled"). This is a **temporary patch** introduced to support
+    XANES workflows, where the per-scan energy step is small
+    (~eV-scale) and the operator wants the A-shutter open
+    continuously to preserve the thermal stability of the upstream
+    optics; auto-closing for every step would create a thermal
+    transient bigger than the XANES step itself.
+
+  - The **intended permanent behaviour** is **conditional**:
+
+    - **Small energy change** (XANES, eV-scale step within or near
+      a single calibrated energy): keep A-shutter open. Current
+      commented-out behaviour is correct for this case.
+    - **Large energy change** (between adjacent calibrated
+      energies, Mono <-> Pink mode switch, any move covering more
+      than ~few keV): **close** the A-shutter for the duration of
+      the move to prevent vacuum bumps from the filter-holder
+      frames crossing the beam during motion.
+
+  - Until the conditional logic is restored to ``move.py``, the
+    A-shutter is in whatever state the operator left it in. For
+    large energy changes the operator should manually close the
+    FES (``S02BM-PSS:FES:CloseEPICSC``) before invoking
+    ``energy set`` and re-open it (``OpenEPICSC``) afterwards;
+    cora-side this is a Plan-level wrap around the energy Method,
+    not a property of the Method itself.
 
 
 Parameters

--- a/docs/source/procedures/item_006.rst
+++ b/docs/source/procedures/item_006.rst
@@ -42,7 +42,7 @@ Preconditions
   (``set_energy_to_preselect``) — the target flag Y depends on
   the current DMM energy via the ``energy_move_flag`` lookup in
   `energy2bm.json
-  <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__.
+  <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__.
 
 
 Parameters
@@ -56,7 +56,7 @@ Parameters
   - ``pink``: ``flag_y_mm = 0`` (lower position, out of beam).
   - ``mono``: ``flag_y_mm = energy_move_flag[current_energy_keV]``
     (read from `energy2bm.json
-    <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__).
+    <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__).
     Indicative values: 13.374 keV → 23 mm, 18 keV → 17 mm,
     20 keV → 15 mm, 25 keV → 12 mm, 30+ keV → 0 mm.
 
@@ -83,7 +83,7 @@ Failure modes
 - Motor fault on ``2bma:m44`` — check the motor record's status
   and clear before retrying.
 - For mono mode: `energy2bm.json
-  <https://github.com/xray-imaging/energy/blob/main/src/energy/data/energy2bm.json>`__
+  <https://github.com/decarlof/energy/blob/main/src/energy/data/energy2bm.json>`__
   has no entry for the current DMM energy — operator must either
   calibrate the lookup or pass ``flag_y_mm`` explicitly.
 - Range check fails — typically operator misread mm vs encoded

--- a/docs/source/procedures/item_013.rst
+++ b/docs/source/procedures/item_013.rst
@@ -1,0 +1,224 @@
+===================================================
+NV200D triggered-step buffer programming
+===================================================
+
+Load the per-axis coded-aperture position list into the two
+Piezosystem Jena NV200D/NET controllers and arm them so each
+rising edge on TRG IN advances to the next position in the buffer.
+Run once at session setup (or whenever the random list needs
+regenerating); the controllers then drive themselves frame-by-frame
+from the FPGA trigger for the rest of the session.
+
+
+Name
+----
+
+``nv200_trigger_step``
+
+
+Source
+------
+
+- **Implementation**: `procedures/nv200_trigger_step.py
+  <https://github.com/decarlof/2bm-procedures/blob/main/procedures/nv200_trigger_step.py>`__
+- **Release notes**: `2bm-procedures CHANGELOG
+  <https://github.com/decarlof/2bm-procedures/blob/main/CHANGELOG.md>`__
+
+Single Python script that connects to both NV200D controllers in
+parallel (asyncio), generates the per-axis position list, loads it
+into each controller's waveform buffer, and arms the FPGA-trigger
+advance. A second variant lives in
+``/home/beams/2BMB/conda/sandbox/nv200/nv200_trigger_step.py`` —
+that one uses raw Telnet and is kept as a reference implementation
+of the vendor's NV200/D NET command vocabulary; it is NOT the
+operationally-blessed script.
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: ``CodedApertureFineDrive_X``
+  (Piezosystem Jena NV200D/NET at ``10.54.113.126``)
+- :doc:`../manual/item_020`: ``CodedApertureFineDrive_Y``
+  (Piezosystem Jena NV200D/NET at ``10.54.113.125``)
+- :doc:`../manual/item_020`: the coded-aperture XY flexure stage
+  itself (Piezosystem Jena ``nanoSXY 120 CAP``, T-223-06D)
+- ``JenaNV200D`` EPICS IOC on ``arcturus`` — must be **stopped**
+  for the duration of the script (one-Telnet-connection-at-a-time
+  constraint on the NV200D)
+
+
+Preconditions
+-------------
+
+- **EPICS IOC `JenaNV200D` is stopped.** The NV200D allows only
+  one Telnet connection at a time; if the IOC holds the connection,
+  the script cannot connect.
+- **Network reachable to both controllers.** ``ping 10.54.113.126``
+  and ``ping 10.54.113.125`` should both succeed from ``arcturus``.
+- **Python environment has the `nv200` library installed.**
+  ``pip install nv200 numpy`` once per environment.
+- **Coded-aperture stage is mechanically aligned in the beam path.**
+  The position list spans the full 0–100 µm closed-loop stroke; if
+  the stage is mis-aligned the random walk will produce nonsense
+  aperture positions even though the script runs cleanly.
+
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 10 50
+
+   * - Argument
+     - Type
+     - Default
+     - Description
+   * - ``--n N``
+     - integer, 1 ≤ N ≤ 1024
+     - 256
+     - Number of positions to load into each controller's waveform
+       buffer. 1024 is the NV200D hardware maximum.
+   * - ``--random``
+     - flag (no value)
+     - off
+     - If set, positions are uniformly sampled from the 0–100 µm
+       stroke (compressive-sensing dithered sampling). If unset,
+       positions are evenly spaced (``numpy.linspace``).
+
+
+Steps
+-----
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 30 65
+
+   * - #
+     - Action
+     - Command / call
+   * - 1
+     - Stop the ``JenaNV200D`` EPICS IOC (via the ``iocs_start``
+       MEDM screen, or whichever IOC-control surface the
+       deployment uses).
+     - operator-side; see :doc:`../ops/item_028`
+   * - 2
+     - Change directory to the procedure script location.
+     - ``cd <path-to-2bm-procedures>/procedures`` (e.g.
+       ``cd ~/conda/2bm-procedures-decarlof/procedures`` or
+       wherever the repo is checked out)
+   * - 3
+     - Run the script with the desired parameters.
+     - ``python nv200_trigger_step.py [--n N] [--random]``
+   * - 4
+     - Wait for the "Running. Each rising edge on TRG IN (I/O
+       connector pin 3) steps to the next position." line. The
+       script blocks here.
+     - watch console output
+   * - 5
+     - (Optional) verify the saved position files match the
+       intended sampling pattern.
+     - ``head -5 positions_x.txt`` (random will look random;
+       linspace will be evenly spaced)
+   * - 6
+     - Run the tomography fly-scans. Each FPGA trigger pulse
+       advances both controllers to their next position.
+     - operator-side; standard tomoscan acquisition
+   * - 7
+     - When scans are complete, return to the script's terminal
+       and press Enter.
+     - keyboard
+   * - 8
+     - Restart the ``JenaNV200D`` EPICS IOC so the rest of the
+       control system can address the controllers again.
+     - operator-side; see :doc:`../ops/item_028`
+
+
+Postconditions
+--------------
+
+On a successful run:
+
+- Both NV200D controllers have their waveform buffer loaded with
+  N positions in 0–100 µm closed-loop stroke.
+- ``TriggerInFunction = WAVEFORM_STEP`` on both controllers (the
+  device-side trigger arms the per-edge step advance).
+- ``positions_x.txt`` and ``positions_y.txt`` saved to the current
+  working directory as a record of the position list actually
+  loaded (so reconstructions later have the per-frame coded-
+  aperture position the scan used).
+
+After the operator presses Enter and the script exits cleanly:
+
+- Both controllers have ``TriggerInFunction = DISABLED`` and the
+  waveform generator stopped (direct command control restored).
+- Telnet connections closed; the ``JenaNV200D`` EPICS IOC can be
+  restarted to reclaim the connections.
+
+(The waveform buffer contents persist in RAM until the controller
+is power-cycled; the script's optional ``save_to_eeprom()`` path
+can persist the buffer across power cycles if needed.)
+
+
+Failure modes
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Symptom
+     - Recovery
+   * - Step 3 raises ``ConnectionRefusedError`` / Telnet refused
+     - The ``JenaNV200D`` EPICS IOC is still running. Stop it
+       (precondition 1) and re-run.
+   * - Step 3 raises ``ValueError: position outside actuator
+       range``
+     - The position list contains values outside 0–100 µm. Should
+       only happen if the stroke limits the controller reports
+       (``posmin`` / ``posmax``) have been edited; verify with
+       ``caget`` after restarting the IOC.
+   * - Step 3 raises ``ValueError: Maximum 1024 positions``
+     - ``--n`` larger than 1024. Reduce to the device maximum.
+   * - Network timeout to one of the IPs
+     - Check ``ping 10.54.113.126`` and ``10.54.113.125`` from
+       ``arcturus``. If unreachable, check the
+       Piezosystem-Jena-controller-side network configuration
+       (per :doc:`../ops/item_028` Network configuration section).
+   * - Script runs but tomography acquisitions do not advance the
+       piezo positions during fly-scan
+     - The FPGA-output-to-NV200D-TRG-IN cable mapping may be
+       wrong. See :doc:`../ops/item_028` FPGA-trigger-integration
+       section and the related open question on the cora
+       deployment-questions page (PIEZO-5).
+   * - Script exits cleanly but ``positions_*.txt`` not saved
+     - The script must be run from a writable directory. ``cd`` to
+       a writable location (step 2) before running.
+
+
+Operator walkthrough
+--------------------
+
+See :doc:`../ops/item_028` for the full operator-side walk-through
+including IOC stop/start, MEDM screens, the FPGA trigger
+integration, the softGlueZynq GateDelay configuration, and the
+Lantronix XPort flow-control settings. This procedure page covers
+only the script invocation and its parameters; everything else
+about operating the NV200D at 2-BM is in ``item_028``.
+
+
+Notes
+-----
+
+- The 1024-position cap is the NV200D's onboard arbitrary-waveform
+  generator buffer size, not a 2-BM-specific limit. 256 positions
+  per axis is the operational default at 2-BM.
+- ``--random`` is the current operational mode for compressive-
+  sensing dithered tomography reconstructions; ``--linspace``
+  (default if the flag is omitted) produces a deterministic raster.
+- For cora-side modelling notes (the two-controller architecture,
+  per-axis IPs, and the per-Run provenance value of the
+  ``positions_*.txt`` snapshot), see the open cora questions PIEZO-1
+  through PIEZO-5 on the
+  `2-BM open-questions page <https://xmap.github.io/cora/deployments/2-bm/questions/>`__.

--- a/docs/source/procedures/item_014.rst
+++ b/docs/source/procedures/item_014.rst
@@ -1,0 +1,220 @@
+============================================
+Energy characterization (channel-cut crystal)
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** The operational walk-through (8-step recipe,
+   crystal parameters, Bragg-law formulas, mdaviz fit instructions)
+   already lives at :doc:`../ops/item_022`. This page is the
+   cora-Procedure-shaped abstraction over that recipe. The formal
+   2bm-procedures script implementation is pending.
+
+
+Name
+----
+
+``energy_characterization``
+
+
+Source
+------
+
+The procedure has two operational layers:
+
+- **Broader alignment workflow** that places the beam into mono mode
+  and arrives at a DMM ready to be calibrated: :doc:`../ops/item_012`
+  (`Beamline alignment` — white beam → pink beam → mono beam).
+  The energy-calibration step happens once the DMM mono beam is
+  established at the end of that walk-through.
+- **Focused calibration recipe** (the 8-step channel-cut rocking-
+  curve sub-procedure): :doc:`../ops/item_022`
+  (`X-ray energy calibration using channel-cut crystal`).
+
+Not yet implemented as a standalone script in
+`2bm-procedures <https://github.com/decarlof/2bm-procedures>`__.
+Future location: `procedures/energy_characterization.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/energy_characterization.py>`__.
+The procedure would scan a removable channel-cut crystal mounted on
+the 2-BM-B sample-rotation stage, fit the rocking curve, and report
+the measured energy + offset from the nominal DMM setting.
+
+
+Devices
+-------
+
+- **Channel-cut crystal** (calibration Subject — removable reference
+  standard, mounted only when calibration is being run):
+
+  - Length: 36 mm
+  - Width: 3 mm
+  - Lattice spacing: ``2d = 3.84 Å`` (consistent with **Si (220)**;
+    operator to confirm crystal cut)
+  - Stored off-beamline between calibrations; brought into the beam
+    on its own kinematic mount for each calibration run.
+
+- **Rotation stage** for rocking the crystal: the 2-BM-B
+  sample-rotation stage (the Aerotech ABRS-150MP described in the
+  :doc:`../manual/item_020` sample-stack block, also tracked by cora
+  STAGE-3 / cora#164). The crystal is mounted in place of the sample
+  for the duration of the calibration.
+
+- :doc:`../manual/item_020`: **DMM** — the optic being calibrated.
+  The procedure measures the actual energy at a specific DMM setting
+  and computes the offset.
+
+- :doc:`../manual/item_020`: detector + areaDetector ROI + Stat2
+  plugins — record reflected intensity in an ROI around the Bragg
+  reflection.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+- :doc:`item_005` (``set_energy_to_preselect``) — DMM at a nominal
+  energy (typically 20 keV per the ops walk-through).
+- :doc:`item_007` (``open_b_shutter``) — beam reaches the
+  calibration crystal.
+- Detector operational with areaDetector ROI plugin enabled.
+- Sample-rotation stage clear (no actual sample mounted; the
+  channel-cut crystal occupies that slot for the calibration).
+
+
+Parameters
+----------
+
+- ``nominal_energy_keV`` (number > 0) — DMM-side nominal energy at
+  which calibration is being performed. Default: 20.0.
+- ``rocking_range_deg`` (number > 0) — half-width of the rocking
+  scan around the calculated Bragg angle. Default: TBD (operator
+  to set per signal-to-noise; ops walk-through suggests "fine
+  angular scan" without prescribing a number).
+- ``rocking_step_deg`` (number > 0) — angular step of the rocking
+  scan. Default: TBD.
+
+
+Steps
+-----
+
+(Distilled from :doc:`../ops/item_022`; the ops page has the full
+narrative + screenshots.)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 35 60
+
+   * - #
+     - Action
+     - Detail
+   * - 1
+     - Mount the channel-cut crystal on the sample-rotation stage in
+       the X-ray beam path.
+     - Align so the incident beam fully illuminates the 3 mm crystal
+       width and the reflection geometry is symmetric. Zero the
+       rotation angle.
+   * - 2
+     - Set DMM to ``nominal_energy_keV`` via :doc:`item_005`.
+     - For 20 keV, expected Bragg angle is ~9.29° (from
+       ``arcsin(12.3984 / (2d · E))`` with ``2d = 3.84 Å``).
+   * - 3
+     - Rotate crystal to the calculated Bragg angle; find the
+       reflected beam on the detector.
+     - Set an ROI in areaDetector around the reflection; use the
+       Stat2 plugin to compute mean intensity in the ROI.
+   * - 4
+     - Run a fine angular rocking scan around the calculated angle.
+     - Record reflected intensity vs angle. Step size and total
+       range are operator-set per signal-to-noise.
+   * - 5
+     - Fit the rocking curve to extract the peak angle
+       :math:`\theta_B`.
+     - The ops walk-through suggests ``mdaviz`` for interactive
+       inspection and fitting:
+       ``/APSshare/bin/mdaviz``.
+   * - 6
+     - Compute the measured energy from Bragg's law.
+     - :math:`E_{meas} = 12.3984 / (2d \cdot \sin\theta_B)`.
+       Report ``offset = E_meas - nominal_energy_keV``.
+   * - 7
+     - Apply offset correction to the monochromator control
+       software, if required.
+     - **How the offset is folded into the saved per-energy table
+       is the scope of cora ENERGY-8 — not in this procedure's
+       scope.**
+   * - 8
+     - Verify calibration: repeat the procedure at a second energy
+       (e.g. 19 or 21 keV) to check linearity / consistency.
+     - Procedure passes if the second-energy offset is within
+       operator-set tolerance of the first.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``energy_characterized``
+   (new condition; not currently a precondition of any other
+   procedure but useful as provenance for a Run: each Run can
+   record "calibrated at YYYY-MM-DD with offset X keV at nominal Y
+   keV").
+
+:Predicate:
+   - ``E_measured`` and ``E_measured - nominal_energy_keV`` (the
+     measured offset) recorded.
+   - At least two nominal energies sampled and offsets agree within
+     tolerance.
+   - Channel-cut crystal removed from the beam path at procedure
+     end (sample-rotation stage is back to its operational state
+     for the next sample).
+
+
+Failure modes
+-------------
+
+- **No reflected beam visible at calculated Bragg angle.** Possible
+  causes: crystal mis-aligned, DMM energy mis-set, ROI not on the
+  reflection spot. Recovery: realign crystal, re-zero rotation,
+  re-check DMM energy with ``caget``.
+- **Rocking curve is asymmetric or has multiple peaks.** Possible
+  causes: crystal contamination, non-monochromatic input (DMM not
+  settled), beam clipped by ROI. Recovery: clean / re-mount crystal,
+  re-set DMM (wait for ``AllDoneA`` / ``AllDoneB``), enlarge ROI.
+- **Offset is large (> several hundred eV at 20 keV).** Likely
+  indicates DMM has drifted significantly; correction is meaningful
+  but operator should check whether something mechanical needs
+  attention (Bragg arm encoder drift, M2 Y miscount, etc.).
+- **Verification at second energy disagrees.** Linearity check
+  failed; offset is not a pure scalar. Procedure outputs both values
+  with a "non-linear calibration" warning; cora-side application of
+  the offset has to decide whether to use it as-is or refit.
+
+
+Operator walkthrough
+--------------------
+
+- :doc:`../ops/item_012` — broader beamline alignment workflow
+  (where this calibration fits as the final step after the mono
+  beam is established).
+- :doc:`../ops/item_022` — full operator-facing channel-cut
+  calibration recipe with screenshots, formula derivations, and the
+  Python snippets for the angle ↔ energy conversion.
+
+
+Notes
+-----
+
+- The channel-cut crystal is a **removable reference standard**, not
+  installed hardware. Cora can model it as a calibration Subject
+  (the same pattern as a resolution phantom — a Subject brought into
+  the beam, exercised, then removed).
+- The cora-side ``energy_characterization`` Procedure target is this
+  page. The crystal is the Procedure's calibration Subject (model
+  field: ``si_channel_cut_220`` or similar, with ``two_d_angstrom =
+  3.84`` and dimensions 36 x 3 mm).
+- The rotation stage used for rocking is the 2-BM-B sample-rotation
+  stage (cora STAGE-3 / cora#164 ``SampleRotaryDrive`` / Aerotech
+  ABRS-150MP), reused as the rocking axis for the calibration. No
+  separate rotation hardware is involved.
+- The actual application of the measured offset (whether folded back
+  into the ``energy2bm.json`` ``store_0`` table, or applied as a
+  separate runtime correction) is the scope of cora ENERGY-8.

--- a/docs/source/procedures/item_014.rst
+++ b/docs/source/procedures/item_014.rst
@@ -135,18 +135,27 @@ narrative + screenshots.)
    * - 6
      - Compute the measured energy from Bragg's law.
      - :math:`E_{meas} = 12.3984 / (2d \cdot \sin\theta_B)`.
-       Report ``offset = E_meas - nominal_energy_keV``.
+       Report ``E_meas`` and ``Delta = E_meas - nominal_energy_keV``
+       (the latter is for human comparison only — it is NOT stored
+       as an offset).
    * - 7
-     - Apply offset correction to the monochromator control
-       software, if required.
-     - **How the offset is folded into the saved per-energy table
-       is the scope of cora ENERGY-8 — not in this procedure's
-       scope.**
+     - Update the calibration table — direct update via
+       ``energy add``, no separate offset stored anywhere.
+     - Two operator-choice options: (a) tweak optics until the
+       rocking-curve peak hits the nominal energy, then
+       ``energy add --energy <nominal>`` overwrites the existing
+       row with the corrected positions; (b)
+       ``energy add --energy <measured>`` adds a new calibrated row
+       at the measured value, leaving the existing row in place.
+       See :doc:`../ops/item_022` step 7 for the explicit CLI
+       invocations. **The cora ENERGY-8 question's "offset folded
+       back vs applied separately" framing does not match the
+       actual mechanism — there is no offset state.**
    * - 8
      - Verify calibration: repeat the procedure at a second energy
        (e.g. 19 or 21 keV) to check linearity / consistency.
-     - Procedure passes if the second-energy offset is within
-       operator-set tolerance of the first.
+     - Procedure passes if the second-energy ``Delta`` (after the
+       step-7 update) is within operator-set tolerance.
 
 
 Postconditions
@@ -159,10 +168,15 @@ Postconditions
    keV").
 
 :Predicate:
-   - ``E_measured`` and ``E_measured - nominal_energy_keV`` (the
-     measured offset) recorded.
-   - At least two nominal energies sampled and offsets agree within
-     tolerance.
+   - ``E_measured`` at the nominal DMM setting recorded.
+   - If ``|E_measured - nominal_energy_keV|`` exceeds operator
+     tolerance, the calibration table has been updated via
+     ``energy add`` (either overwriting the existing row at the
+     nominal, or adding a new row at the measured value — operator
+     choice per step 7). The calibration table itself IS the
+     authoritative state; no separate offset is stored.
+   - At least two nominal energies sampled and the post-update
+     ``Delta`` is within tolerance at both.
    - Channel-cut crystal removed from the beam path at procedure
      end (sample-rotation stage is back to its operational state
      for the next sample).
@@ -179,14 +193,19 @@ Failure modes
   causes: crystal contamination, non-monochromatic input (DMM not
   settled), beam clipped by ROI. Recovery: clean / re-mount crystal,
   re-set DMM (wait for ``AllDoneA`` / ``AllDoneB``), enlarge ROI.
-- **Offset is large (> several hundred eV at 20 keV).** Likely
-  indicates DMM has drifted significantly; correction is meaningful
-  but operator should check whether something mechanical needs
-  attention (Bragg arm encoder drift, M2 Y miscount, etc.).
-- **Verification at second energy disagrees.** Linearity check
-  failed; offset is not a pure scalar. Procedure outputs both values
-  with a "non-linear calibration" warning; cora-side application of
-  the offset has to decide whether to use it as-is or refit.
+- **``Delta`` is large (> several hundred eV at 20 keV).** Likely
+  indicates DMM has drifted significantly since the last
+  calibration. The ``energy add`` step still works (the calibration
+  table can absorb any single-point correction), but the operator
+  should check whether something mechanical needs attention (Bragg
+  arm encoder drift, ``M2 Y`` miscount, etc.) before saving.
+- **Verification at second energy disagrees after step-7 update.**
+  Single-point calibration was applied; multiple nearby energies
+  still show large ``Delta``. Likely the underlying issue isn't a
+  single-energy shift but a curve-shape problem (e.g., d-spacing
+  drift, mechanical zero shift). Operator should re-calibrate the
+  affected energies via additional ``energy add`` calls and / or
+  investigate the mechanical root cause.
 
 
 Operator walkthrough
@@ -215,6 +234,13 @@ Notes
   stage (cora STAGE-3 / cora#164 ``SampleRotaryDrive`` / Aerotech
   ABRS-150MP), reused as the rocking axis for the calibration. No
   separate rotation hardware is involved.
-- The actual application of the measured offset (whether folded back
-  into the ``energy2bm.json`` ``store_0`` table, or applied as a
-  separate runtime correction) is the scope of cora ENERGY-8.
+- **No "energy offset" state is stored anywhere in the system.**
+  The cora ENERGY-8 question's framing — "is the offset folded back
+  into the saved table or applied separately?" — implies a stored
+  offset that doesn't exist. The actual mechanism: the calibration
+  table itself (``energy2bm.json`` ``store_0``) is updated directly
+  via ``energy add``, capturing the current motor positions as the
+  authoritative calibration for the named energy. Step 7 above is
+  the operational form of this. ENERGY-8 should be answered as
+  "neither — there is no offset; the table IS the truth, updated in
+  place".

--- a/docs/source/procedures/item_015.rst
+++ b/docs/source/procedures/item_015.rst
@@ -1,0 +1,283 @@
+============================================
+Beamline alignment (white -> pink -> mono)
+============================================
+
+.. warning::
+
+   **STATUS: STUB.** The full operator-facing alignment recipe with
+   screenshots already lives at :doc:`../ops/item_012`. This page
+   is the cora-Procedure-shaped abstraction over that recipe. The
+   formal 2bm-procedures script implementation is pending.
+
+   Procedure granularity is an open design decision — the operator
+   will decide at implementation time whether this is a single
+   ``align_beamline`` Method with three phases (white / pink /
+   mono), or three separate Methods (``align_white_beam``,
+   ``align_pink_beam``, ``align_mono_beam``) chained in a Plan.
+   The stub assumes the single-method-with-three-phases shape for
+   now; restructure when the script is written.
+
+
+Name
+----
+
+``align_beamline``
+
+
+Source
+------
+
+Operational walk-through with screenshots: :doc:`../ops/item_012`
+(`Beamline alignment`).
+
+Not yet implemented as a standalone script in
+`2bm-procedures <https://github.com/decarlof/2bm-procedures>`__.
+Future location: `procedures/align_beamline.py
+<https://github.com/decarlof/2bm-procedures/blob/main/procedures/align_beamline.py>`__.
+The procedure would orchestrate the three sequential alignment
+phases (white beam centring, pink-beam tuning, mono-beam DMM
+setup) — see Steps below.
+
+Followed at session start (commissioning, start of beamtime, or
+after any major optics intervention). Each phase touches a
+distinct optic set; phases must run in order because the later
+phases assume the earlier ones have already established their
+beam state.
+
+
+Devices
+-------
+
+- :doc:`../manual/item_020`: **Mirror M1** — phase 1 (white-beam
+  centring) and phase 2 (pink-beam set-angle) use the mirror's
+  ``Yaverage`` and angle composite axes; phase 3 (mono) re-asserts
+  the mirror state.
+- :doc:`../manual/item_020`: **DMM** — phase 3 walks the operator
+  through DMM Y stages (``USY OB`` / ``USY IB`` / ``DSY``), the two
+  Bragg arms (``2bma:m30`` / ``2bma:m31``), and ``M2 Y`` (``m32``).
+  Phase 3 ends with a documented arm-angle / M2 Y target that
+  defines the mono setup.
+- :doc:`../manual/item_020`: **2-BM-A area detector** at
+  ``2bma:m21`` (camera vertical) — operator uses this detector
+  through all three phases to image the beam and judge alignment.
+- ImageJ + the EPICS_NTNDA plug-in (or equivalent live viewer) —
+  external tool dependency for line-profile and centring
+  judgements.
+
+
+Preconditions
+-------------
+
+- :doc:`item_003` (``enable_beamline``).
+- :doc:`item_007` (``open_b_shutter``) — actually, phase 1 needs
+  WHITE beam, so the upstream A-shutter open + DMM out of beam.
+  Operator-driven shutter handling per phase rather than a single
+  precondition.
+- Detector running in 2-BM-A
+  (``2bmbOryx5MP medm`` + ``2bmbOryx5MP run`` from the ops
+  walk-through).
+- No beam-hazardous samples in the path (alignment uses raw
+  white / pink / mono beam directly on the detector).
+
+
+Parameters
+----------
+
+- ``do_white`` (boolean, default true) — run phase 1
+  (white-beam alignment).
+- ``do_pink`` (boolean, default true) — run phase 2
+  (pink-beam alignment).
+- ``do_mono`` (boolean, default true) — run phase 3
+  (mono-beam DMM alignment).
+- ``request_steering`` (boolean, default true) — if the white-beam
+  vertical profile is not symmetric, the procedure pauses and
+  prompts the operator to request beam steering from the APS
+  control room (in 10 µrad steps per ops/item_012). If set false,
+  procedure proceeds without the steering pause.
+
+
+Steps
+-----
+
+(Distilled from :doc:`../ops/item_012`; the ops page has the full
+narrative + screenshots.)
+
+**Phase 1 — White-beam centring**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 35 60
+
+   * - #
+     - Action
+     - Detail
+   * - 1.1
+     - Start the 2-BM-A detector and ImageJ live viewer.
+     - ``2bmbOryx5MP medm`` + ``2bmbOryx5MP run``; ``ImageJ`` with
+       EPICS_NTNDA plug-in configured.
+   * - 1.2
+     - Lower M1 out of the beam.
+     - ``Yaverage = -2 mm``, ``Angle = 0 mrad``.
+   * - 1.3
+     - Lower the DMM out of the beam.
+     - ``USY-OB`` = ``USY-IB`` = ``DSY`` = ``-19 mm``.
+   * - 1.4
+     - Adjust camera vertical (``2bma:m21``) until the white beam
+       is visible.
+     - 1 mm Al filter + 20 mm glass; exposure 0.004 s typical.
+       Remove the Al filter once the beam is found.
+   * - 1.5
+     - Verify vertical line profile is symmetric. If not, pause
+       and request beam steering from the APS control room in
+       10 µrad steps (per ``request_steering`` parameter).
+     - Control-room instructions linked from ops/item_012.
+
+**Phase 2 — Pink-beam alignment**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 35 60
+
+   * - #
+     - Action
+     - Detail
+   * - 2.1
+     - Insert M1 into the beam.
+     - ``Yaverage = 0 mm``, ``Angle = 0 mrad``.
+   * - 2.2
+     - Recalibrate M1 ``Yaverage`` until the mirror cuts the white-
+       beam image in half; recalibrate M1 angle until the reflected
+       beam disappears; then reset both to zero.
+     - Enable the Proc1 plugin + Save / Enable Flat Field for
+       reflected-beam visibility.
+   * - 2.3
+     - Set M1 angle to ``2.618 mrad`` (= 0.15 deg) to put the
+       beamline in pink mode.
+     - Move camera up until pink beam is visible.
+   * - 2.4
+     - Adjust camera vertical until the pink-beam image is
+       centred; set camera Y to 0 at that position.
+     - Defines the pink-beam centred reference.
+
+**Phase 3 — Mono-beam DMM alignment**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 35 60
+
+   * - #
+     - Action
+     - Detail
+   * - 3.1
+     - Set DMM Y stages and Upstream-arm angle to zero.
+     - ``USY-OB`` = ``USY-IB`` = ``DSY`` = ``0``;
+       Upstream-arm angle = ``0 deg``.
+   * - 3.2
+     - Recalibrate DMM table height + first-crystal angle: drive
+       Y stages until the first crystal cuts the pink beam in
+       half; drive Upstream-arm until the reflected beam
+       disappears. Then reset to zero.
+     - First-crystal calibration.
+   * - 3.3
+     - Recalibrate second-crystal angle: drive Y stages down by
+       10 mm; drive ``DMM M2Y`` down until the second crystal
+       cuts the pink beam in half; drive second-crystal angle
+       until the reflected beam disappears. Then set
+       ``DMM M2Y = 10 mm`` and ``DMM Downstream-arm = 0 deg``.
+     - Second-crystal calibration.
+   * - 3.4
+     - Locate the DMM mono beam.
+     - Move DMM into beam (``USY-OB`` = ``USY-IB`` = ``DSY`` = 0);
+       set Upstream-arm to ``1.25 deg``; compute target
+       ``M2Y = tan(2 * 1.25 deg) * 600 mm = 26.196 mm`` and set
+       ``M2Y`` and detector Y (``2bma:m21``) to that value.
+   * - 3.5
+     - Adjust detector Y until the DMM monochromatic beam is
+       visible.
+     - Should be near the calculated position.
+   * - 3.6
+     - Maximise intensity and beam size by adjusting **only**
+       Downstream-arm and ``M2Y``.
+     - All other DMM axes already calibrated by step 3.2 / 3.3.
+   * - 3.7
+     - Set the second-crystal angle (Downstream-arm) back to
+       ``1.25 deg``.
+     - Final mono setup.
+   * - 3.8
+     - (Optional) Run the
+       :doc:`item_014` (``energy_characterization``) procedure to
+       verify the absolute energy via the channel-cut crystal
+       calibration.
+     - Standard follow-on; calibrates the just-aligned mono beam.
+
+
+Postconditions
+--------------
+
+:Satisfies: ``beamline_aligned`` (new condition — not currently a
+   precondition of any other procedure, but useful as per-Run
+   provenance: each Run can record "aligned on YYYY-MM-DD,
+   mono-beam intensity X at energy Y").
+
+:Predicate:
+   - Mirror M1 is at the appropriate state for the requested beam
+     mode (out for white, in at 2.618 mrad for pink, in for mono).
+   - DMM is at the appropriate state for the requested beam mode
+     (out for white / pink, in with calibrated Bragg / M2Y for
+     mono).
+   - Detector vertical position has been adjusted to image the
+     selected beam.
+   - 2-BM-A detector intensity profile is symmetric.
+
+
+Failure modes
+-------------
+
+- **White-beam vertical profile is asymmetric after steering**:
+  multiple 10 µrad steering iterations not converging. May indicate
+  upstream optic drift; escalate to APS controls.
+- **M1 angle calibration does not produce a clean
+  reflected-beam-disappearance signal**: typically indicates the
+  Proc1 flat-field reference is stale or the mirror Yaverage is
+  off-centre by more than the recalibration step can capture.
+  Restart phase 2 from scratch.
+- **DMM M2Y measured value disagrees with the calculated
+  ``26.196 mm``** by more than a few hundred microns: ops/item_012
+  notes that if the optimised value is ``26.046 mm`` the effective
+  crystal-to-crystal distance is ``596.56 mm`` (not the
+  600 mm assumption). Procedure should record the measured
+  crystal-distance value as procedure provenance.
+- **Mono beam is dim or has multiple spots after step 3.6**:
+  multilayer-stripe contamination or DMM Y misalignment. Restart
+  phase 3 from scratch.
+
+
+Operator walkthrough
+--------------------
+
+Full operator-facing recipe with screenshots: :doc:`../ops/item_012`.
+
+The channel-cut energy calibration follow-on (step 3.8) is
+:doc:`../ops/item_022` (the focused recipe) or
+:doc:`item_014` (the cora-Procedure stub).
+
+
+Notes
+-----
+
+- This procedure is the natural cora "session-start" Method for
+  the 2-BM deployment. Every Run that starts at a fresh
+  beam-conditioned state would have a recent
+  ``align_beamline`` invocation as its precondition or its
+  documented provenance.
+- The 600 mm inter-crystal distance assumption is worth
+  noting: ops/item_012 uses 600 mm in the M2Y target calculation
+  and flags 596.56 mm as the observed-effective value. The DMM
+  block in :doc:`../manual/item_020` has a different inter-crystal
+  spacing value (``1323 mm along beam, 765 mm in / out-board``) which
+  appears to describe a different geometric measurement; the
+  600 mm figure is the M2Y-relevant one used in the alignment
+  formula.
+- Procedure granularity (one Method vs three) is a design call
+  for the formal 2bm-procedures implementation; the stub assumes
+  one Method with three optionally-skippable phases.


### PR DESCRIPTION
## Summary

Sixteen commits answering eighteen 2-BM cora-deployment questions, all driven by the per-question workflow on `xmap.github.io/cora/deployments/2-bm/questions/`. The batch covers the front-end + DMM + Mirror + Pink/Mono mode + 2-BM-A alignment camera + microscope dual-role usage; one operational doc bug fix (pre-APS-U M3-24 mask aperture in `ops/item_012`); one operational doc bug fix
 (A-shutter handling in `ops/item_022` step 7 + `procedures/item_005`); a canonical-document migration from APS_1404611 to APS_2191941; two new cora-procedure stubs (`item_014` energy characterization, `item_015` beamline alignment).

## Cora questions cleared by this PR

| Cora # | Question | Doc commit(s) |
|---|---|---|
| #246 | BEAM-2: Be window stack count + thickness | `13bb6dc` |
| #247 | BEAM-3: P6-50 safety shutter drawing numbers | `13bb6dc` |
| #249 | ENERGY-1: per-energy DMM Bragg arms + M2 vertical (m30/m31/m32) | `2899c86` |
| #250 | ENERGY-2: per-energy B-station slit vertical pair (m9/m10) | `2899c86` |
| #251 | FLAG-1: diagnostic flag location, per-energy Y, Pink parked | `3a9a1c9` |
| #252 | ENERGY-3: saved-table vs Bragg-computation | (covered by `2899c86` + `8d5be8d` + `9ce6c44`) |
| #253 | ENERGY-4: continuously tunable vs discrete | (covered by `2899c86` + `8d5be8d`) |
| #254 | ENERGY-5: do DMM tank/alignment motors vary per energy | `a733802` |
| #255 | ENERGY-6: DMM multilayer stripe selection mechanism | `98fa1a4` |
| #256 | ENERGY-7: channel-cut crystal energy calibration | `20b7fda` (item_014 stub) |
| #257 | ENERGY-8: offset-folded-back vs runtime-correction (answer: neither) | `9ce6c44` |
| #259 | MIRROR-1: M1 stripe held in Mono, swept in Pink, stripe-to-position map | `a005f1c` |
| #260 | MODE-1: two beam modes + energy menus | (no doc change needed) |
| #261 | MODE-2: physical DMM insert / bypass mechanism + A-shutter handling | `47cc5f0` + `dc69b40` |
| #262 | MODE-3: Pink-mode per-energy m3 + table-X + stripe-to-position map | (covered by `a005f1c`) |
| #263 | ALIGN-1: 2-BM-A alignment camera as semi-permanent inventory | `b61cb46` |
| #264 | ALIGN-2: front-end mask aperture (correction 50x3 -> 44.4x4.5 mm) | `0151e1f` |
| #265 | VIB-1: vibration camera = same physical FLIR Oryx as microscope | `c68b68a` |

## Notable substantive changes (beyond per-question answers)

### Canonical document migration: APS_1404611 -> APS_2191941

The post-APS-U revision of the 02-BM Beamline Component Reference Table (PDRC TN25-015, approved 04 Aug 2025, edited 25 Sep 2025) supersedes the 2013 pre-APS-U table that `item_020.rst` previously cited. Commit `13bb6dc` swaps the reference at the top of "Beam delivery" and narrows the pre-APS-U caveat to specific per-component blocks whose z values haven't been reconciled yet (Y3-30
 Mirror, DMM crystals, P6-50 assembly). Be window stack + P6-50 drawing numbers added in the same commit.

### Energy-package documentation alignment: xray-imaging -> decarlof fork

Commit `4fc6fe4` swaps every post-APS-U reference to `github.com/xray-imaging/energy` for `github.com/decarlof/energy` (the live fork; reconciled with upstream via PR periodically). The intentional fork-relationship narrative is preserved in three places (item_005 Source section, item_005 Notes section, procedures.rst index entry). Same commit rewrites the `set_energy_to_preselect` s
tub to reflect that linear interpolation IS in production at `util.py::interpolate()` (earlier framing had it as a missing feature).

### "Energy offset" terminology removed

Commit `9ce6c44`. The `energy` CLI does not maintain a separate "offset" state. After a channel-cut calibration, the operator updates the per-energy table directly via `energy add --energy <value>`, which captures the current beamline motor positions. `ops/item_022` step 7 previously said "Apply an energy-offset correction in the control software if required"; replaced with the two e
xplicit `energy add` workflows. `procedures/item_014` Notes section explicitly flags the cora ENERGY-8 framing mismatch.

### A-shutter handling during energy change is operator-managed

Commits `47cc5f0` and `dc69b40`. The deployed `move.py::motors()` has both the close and re-open calls explicitly commented out (the close-side log line still prints "closing A-shutter" misleadingly). This is a temporary XANES-friendly patch (small XANES steps should NOT auto-close the shutter, to preserve upstream-optic thermal stability). Intended permanent behaviour is conditional
 close based on energy-change magnitude (large moves should close to prevent vacuum bumps from filter-holder frames crossing the beam). Until the conditional logic is restored, the A-shutter is operator-managed and the cora MODE-2 model treats it as a Plan-level wrapper around the energy Method. `procedures/item_005.rst` Preconditions corrected accordingly.

### Two new procedure stubs

Both follow the existing cora-Procedure template (Name / Source / Devices / Preconditions / Parameters / Steps / Postconditions / Failure modes / Operator walkthrough / Notes):

- `procedures/item_014.rst` (`energy_characterization`, commit `20b7fda`) wraps the channel-cut crystal energy-calibration recipe at `ops/item_022.rst`. Crystal modelled as a removable calibration Subject (Si (220) inference from `2d = 3.84 A`; operator confirmation of the cut still pending).
- `procedures/item_015.rst` (`align_beamline`, commit `3eaf7eb`) wraps the three-phase white -> pink -> mono beamline-alignment recipe at `ops/item_012.rst`. Granularity caveat called out: stub assumes one Method with three optionally-skippable phases, but the formal 2bm-procedures implementation may prefer three separate Methods chained in a Plan.

Neither has a script implementation yet in [2bm-procedures](https://github.com/decarlof/2bm-procedures); the stubs are the cora-modellable specs.

### Per-energy data snapshots in `item_020.rst`

Commits `2899c86` (DMM Bragg arms + M2 + B-slits), `a733802` (DMM tank motors), `98fa1a4` (DMM stripe Bragg cross-check), `a005f1c` (M1 stripe-to-position map). All values sourced from the live `energy2bm.json` `store_0` field at `/home/beams/2BMB/epics/synApps/support/energy/src/energy/data/energy2bm.json` (decarlof/energy fork main branch). Reproduced as snapshots in the docs; the 
JSON is the authoritative source.

Bragg-arm cross-check confirmed two design assumptions:

- The DMM stripe currently in use is the 24 A multilayer (commit `98fa1a4`): `d = lambda / (2 sin theta)` computed from m30 angles + Bragg's law gives d ~ 23.5..24.75 A across all 6 Mono energies; no values near 13.8 A. The 13.8 A stripe is on the substrate but has never been operationally calibrated.
- The Bragg-arm angle units in `energy2bm.json` are degrees (commit `98fa1a4` Note section): the d ~ 24 A consistency check across all 6 Mono rows holds only in degrees.

### Mask aperture correction

Commit `0151e1f`. `ops/item_012.rst` line 8 previously cited the front-end exit mask as "50 mm x 3 mm (H x V)" (pre-APS-U value). The post-APS-U M3-24 aperture per APS_2191941 row 1 is 44.4 x 4.5 mm. Corrected the cited dimensions and added a new "Front-end exit mask (M3-24)" sub-section to `item_020.rst` (parallel to the Be window stack sub-section added for BEAM-2). If an operator 
following `item_012` was looking for a 50 x 3 mm beam shape on the detector during white-beam centring, the visual check would have looked slightly off.

### New inventory entries in `item_020.rst`

- Coded aperture (Jena NV200D piezo) sub-block at z = 51,300 mm with two-controller architecture, IPs, actuator (nanoSXY 120 CAP), and triggered-step programming reference (pre-existing from PIEZO-1..-5 work).
- Be window stack sub-section (3 windows, total 0.63 mm Be; from APS_2191941 rows 5/8/9).
- DMM stripe-substrate description (two stripes 13.8 A / 24 A, 4 mm apart; from `ops/item_021.rst`).
- DMM tank/alignment motors (m25-m29) sub-block (mode-dependent, not per-energy).
- M1 in-vacuum stripe selector stripe-to-position map (a/b/c/d <-> m3 + table-X).
- 2-BM-A alignment camera (FLIR Oryx 5MP on `2bma:m21`, IOC `2bmbOryx5MP` on `lyra`).
- Front-end exit mask (M3-24).
- MCTOptics camera 0 "Dual-role" annotation (vibration / flat-field stability measurement = same physical FLIR Oryx 5MP at 99 fps).

## What this PR does NOT touch

- `docs/source/pre_apsu/**` (historical pre-APS-U content; left as-is even where it carries `xray-imaging/energy` URLs or pre-APS-U mask dimensions).
- Per-component z-position reconciliation in `item_020.rst` against APS_2191941 (Y3-30 Mirror, DMM crystals, K4-21 Collimator, P6-50 assembly) -- the document-reference header is updated but the per-block z values still carry the pre-APS-U numbers. Flagged in commit `13bb6dc` as a separate future pass.
- BLEPS PV inventory / handling (cora BLEPS-1/-2/-3) -- deferred per operator until support-team EPICS integration is complete.
- BEAM-2 supplementary on-site lookup (no per-component thickness measurement -- the APS_2191941 entries are authoritative).

## Test plan

- [ ] `make html` builds clean (no Sphinx warnings beyond the pre-existing baseline).
- [ ] ReadTheDocs auto-build picks up the merged commit on the `main` branch and the live docs render the new sub-sections (Be window stack, Front-end exit mask, 2-BM-A alignment camera, DMM tank/alignment motors, M1 stripe-to-position map, MCTOptics dual-role annotation).
- [ ] New procedure pages `item_014.rst` and `item_015.rst` render with their list-table Steps blocks intact.
- [ ] Internal `:doc:` cross-references resolve (e.g., `procedures/item_005 <-> item_014 <-> item_015 <-> manual/item_020 <-> ops/item_012 <-> ops/item_022`).

## Commits in this PR (newest first)

```
c68b68a  docs(item_020): MCTOptics camera 0 dual-role annotation [VIB-1 / cora#265]
0151e1f  docs: M3-24 exit mask aperture correction + item_020 sub-section [ALIGN-2 / cora#264]
b61cb46  docs(item_020): 2-BM-A alignment camera block [ALIGN-1 / cora#263]
dc69b40  docs(procedures/item_005): A-shutter XANES-patch framing [MODE-2 / cora#261]
47cc5f0  docs(procedures/item_005): A-shutter NOT auto-closed [MODE-2 / cora#261]
a005f1c  docs(item_020): Mirror M1 stripe-to-position map [MIRROR-1 / cora#259]
9ce6c44  docs: drop "energy offset" terminology, use `energy add` workflow [ENERGY-8 / cora#257]
3eaf7eb  docs(procedures/item_015): align_beamline stub [ENERGY-7 / cora#256 follow-on]
20b7fda  docs(procedures/item_014): energy_characterization stub [ENERGY-7 / cora#256]
98fa1a4  docs(item_020): DMM two-stripe substrate + active 24A stripe inference [ENERGY-6 / cora#255]
a733802  docs(item_020): DMM tank/alignment motors m25-m29 sub-block [ENERGY-5 / cora#254]
4fc6fe4  docs: cite decarlof/energy fork (live) instead of xray-imaging/energy (upstream)
8d5be8d  docs(procedures/item_005): expand set_energy_to_preselect stub with both execution paths
2899c86  docs(item_020): per-energy DMM Bragg arms / M2_Y / B-slits tables [ENERGY-1, ENERGY-2 / cora#249, #250]
3a9a1c9  docs(item_020): Flag block cora bindings [FLAG-1 / cora#251]
13bb6dc  docs(item_020): adopt APS_2191941; Be window stack; P6-50 drawings [BEAM-2, BEAM-3 / cora#246, #247]
```