### PR TITLE
docs(item_021): link the multilayer substrate correction specification

### DIFF
--- a/docs/source/ops/item_021.rst
+++ b/docs/source/ops/item_021.rst
@@ -304,3 +304,70 @@ Two characteristic vertical spacings can be measured on the DMM stripe pattern
 | Coarse spacing (envelope of strong   | ≈ 700    | ≈ 2415    |
 | bands)                               |          | (≈ 2.4 mm)|
 +--------------------------------------+----------+-----------+
+
+Substrate correction specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An engineering analysis of the substrate height power-spectral-density
+(PSD) has been produced as the basis for a substrate-improvement
+specification: `2-BM Multilayer Substrate Stripe-Reduction Specification`_.
+The report derives the mirror-surface height and slope tolerances that
+would produce <2% RMS detector-intensity variation, and compares the
+measured PSD from the ``S11-AHU505_1000frms_99fps_001.h5`` dataset
+(the same acquisition characterised in the *Vertical intensity
+modulation* subsection above) against that target.
+
+The analysis uses the geometry documented in this page: grazing
+angle 12.882 mrad, source-to-optic distance ``p = 29.9342 m``,
+optic-to-detector distance ``q = 24.0658 m``, point-source
+magnification ``M = (p+q)/p = 1.804``, a 3.45 µm detector pixel, and
+a 12 µm RMS vertical source producing a 9.647 µm RMS Gaussian blur
+at the detector plane.
+
+Main findings:
+
+- The measured substrate height PSD **exceeds** the specification
+  required for <2% RMS detector-intensity variation across the
+  mid- to low-spatial-frequency range.
+- Recommended correction: best-effort broadband ion-beam figuring
+  (IBF) over mirror-surface periods from **8.1 mm to the full mirror
+  length** (145 mm).
+- Overall measured height RMS on the current substrate is **6.9 nm**.
+  Corresponding total-band targets are 3.11 nm (5% intensity-RMS
+  target), 1.24 nm (2%), and 0.62 nm (1%).
+- Two spectral maxima in the PSD sit at mirror periods of 14.50 mm
+  and 48.33 mm, but these are maxima within predefined search bands
+  rather than deterministic narrow spectral lines. The data support
+  broadband correction, not cancellation of two discrete sinusoidal
+  periods.
+- Both a geometric ray-density model and a Fresnel wavefront-
+  propagation calculation are given in the report; the two agree
+  closely for mirror periods above ~8 mm and diverge only at the
+  shortest periods where diffraction dominates.
+
+Analytic single-frequency height and slope tolerances at the two
+identified spectral maxima (excerpted from Section 3 of the report):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 25 30
+
+   * - Mirror period (mm)
+     - Intensity RMS target
+     - Height RMS limit (nm)
+     - Slope RMS limit (nrad)
+   * - 14.50
+     - 2%
+     - 0.053
+     - 22.8
+   * - 48.33
+     - 2%
+     - 0.565
+     - 73.4
+
+Full derivation, the analytic single-frequency model, the measured
+PSD plot with 1% / 2% / 5% envelopes overlaid, and the height/slope
+tolerance curves across the full mirror-period range are in the
+report.
+
+.. _2-BM Multilayer Substrate Stripe-Reduction Specification: https://anl.box.com/s/vnpnet5n9ep67v5luilggwg5852u5zaa


### PR DESCRIPTION
Adds a new H4 subsection ("Substrate correction specification") at the end of "Stripe-Free Multilayer" that surfaces the external engineering report defining the IBF correction target for the multilayer substrate.

Motivation: the existing "Vertical intensity modulation" subsection characterises the problem (M1 slow modulation + DMM fast stripe pattern from `S11-AHU505_1000frms_99fps_001.h5`), but the docs carried nothing on the correction-target side: the mirror-surface height and slope tolerances that would deliver <2% RMS detector-intensity variation, and how the currently-measured substrate PSD compares against them. That analysis exists as an external report; this commit brings a summary and a stable link into the docs so anyone reading the modulation characterisation finds the correction spec next to it.

External source (kept on Box, not vendored into the repo): https://anl.box.com/s/vnpnet5n9ep67v5luilggwg5852u5zaa ("2-BM Multilayer Substrate Stripe-Reduction Specification")

New subsection captures the report's operational takeaways:

- Measured substrate height PSD EXCEEDS the <2% RMS detector-intensity specification across the mid- to low-spatial-frequency range.
- Recommended correction: broadband ion-beam figuring (IBF) over mirror periods from 8.1 mm to the full 145 mm mirror length.
- Overall measured height RMS 6.9 nm vs. total-band targets 3.11 nm (5%), 1.24 nm (2%), 0.62 nm (1%).
- Two spectral maxima at 14.50 mm and 48.33 mm are broadband features (maxima within predefined search bands), not deterministic narrow spectral lines. The data support broadband correction, not cancellation of two discrete sinusoidal periods.
- Both a geometric ray-density model and a Fresnel wavefront- propagation calculation are reported; they agree closely for periods above ~8 mm and diverge only at the shortest periods where diffraction dominates.
- Single-frequency tolerance excerpts at the two identified periods are tabulated: 2% intensity RMS gives 0.053 nm height / 22.8 nrad slope at 14.50 mm, and 0.565 nm / 73.4 nrad at 48.33 mm.

Geometry cross-check: the report uses source-to-optic p = 29.9342 m, optic-to-detector q = 24.0658 m, grazing 12.882 mrad, and point-source magnification M = (p+q)/p = 1.804. These match the values now documented on this page after the recent DMM-distance fix (commit 6eb2468) - external confirmation that the corrected geometry is what downstream engineering is using.

No author names in the added prose, per operator request; the report itself is attributed at its source URL.

Sphinx `make html` clean on the DECARLO checkout; the new subsection renders as a peer H4 under Stripe-Free Multilayer alongside Reference documents, Post APS-U component Z positions, and Vertical intensity modulation.