### PR TITLE
docs(nv200): document the dedicated `nv200` conda env for the triggered-step run

### DIFF
--- a/docs/source/ops/item_028.rst
+++ b/docs/source/ops/item_028.rst
@@ -124,8 +124,16 @@ D-Sub, 0/3.3–5 V) advances the actuator to the next position.
    Stop the EPICS IOC before running the script — only one Telnet
    connection is allowed at a time. Restart the IOC when done.
 
-Install the required Python library::
+Activate the dedicated ``nv200`` conda env (Python 3.12,
+``/home/beams/2BMB/conda/anaconda/envs/nv200``), which already has the
+required ``nv200`` + ``numpy`` libraries installed::
 
+  conda activate nv200
+
+To recreate the env from scratch::
+
+  conda create -n nv200 python=3.12 -y
+  conda activate nv200
   pip install nv200 numpy
 
 The script lives in the ``2bm-procedures`` repository

--- a/docs/source/procedures/item_013.rst
+++ b/docs/source/procedures/item_013.rst
@@ -56,8 +56,18 @@ Preconditions
   the script cannot connect.
 - **Network reachable to both controllers.** ``ping 10.54.113.126``
   and ``ping 10.54.113.125`` should both succeed from ``arcturus``.
-- **Python environment has the `nv200` library installed.**
-  ``pip install nv200 numpy`` once per environment.
+- **The `nv200` conda environment is active.** At 2-BM the script
+  runs under the dedicated ``nv200`` conda env (Python 3.12,
+  ``/home/beams/2BMB/conda/anaconda/envs/nv200``), which has the
+  ``nv200`` + ``numpy`` libraries installed::
+
+    conda activate nv200
+
+  To recreate it from scratch::
+
+    conda create -n nv200 python=3.12 -y
+    conda activate nv200
+    pip install nv200 numpy
 - **Coded-aperture stage is mechanically aligned in the beam path.**
   The position list spans the full 0–100 µm closed-loop stroke; if
   the stage is mis-aligned the random walk will produce nonsense


### PR DESCRIPTION
The NV200D triggered-step script runs under a dedicated `nv200` conda env
(Python 3.12, /home/beams/2BMB/conda/anaconda/envs/nv200) with nv200 +
numpy installed — not the `ops` env, as previously assumed. Recording it
so the run is reproducible and the operator knows which env to activate.

- ops/item_028: replace the bare `pip install nv200 numpy` block with
  `conda activate nv200`, plus the recreate-from-scratch commands.
- procedures/item_013: same env info added to the preconditions.
