### PR TITLE
ops/NV200D: document Python-library flow-control side effect and cleanup semantics

### DIFF
--- a/docs/source/ops/item_028.rst
+++ b/docs/source/ops/item_028.rst
@@ -60,6 +60,36 @@ the Lantronix XPort web interface for the EPICS support to work correctly.
 
    Lantronix XPort Serial Settings — Channel 1 flow control configuration (Y axis).
 
+.. warning::
+
+   The ``nv200`` Python library (see `Triggered step mode`_ below) calls
+   ``configure_flow_control(XON_XOFF_PASS_TO_HOST)`` on connect when
+   ``auto_adjust_comm_params=True`` (its default). This is a **persistent
+   NVM write** to the XPort and silently flips the flow-control mode
+   from ``Xon/Xoff`` (Flow 01) to ``XON_XOFF_PASS_TO_HOST`` (Flow 05).
+
+   In Flow 05, controller replies come wrapped with XOFF/XON bytes
+   (``\x13meas,-10.750\r\x00\n\x11``) that the shared stream proto
+   (``$(IP)/db/JenaNV100D.proto``) cannot parse; the EPICS IOC's
+   ``read`` records then sit at ``SEVR=INVALID``, ``STAT=CALC`` even
+   though `write` still forwards to the controller.
+
+   If the EPICS side stops updating after a Python session, either:
+
+   1. Reset the XPort back to ``Xon/Xoff`` (Flow 01) via the web UI,
+      **and** either patch the ``nv200_trigger_step.py`` call site to
+      pass ``auto_adjust_comm_params=False`` or refuse to run any
+      library code that would flip the mode again. Fragile — the next
+      default-parameter Python run breaks it again.
+   2. Or install a local proto override at
+      ``iocBoot/iocJenaNV200D/JenaNV100D.proto`` that accepts the
+      framed reply (add a leading ``\x13`` on each ``read*`` ``in``
+      line). Because ``STREAM_PROTOCOL_PATH=".:$(IP)/db"``, the local
+      file wins over the shared support module for this IOC only.
+      See the 32-ID equivalent page in the 32-ID docs
+      (``manual/manual_030`` "Device configuration") for the concrete
+      diff applied at 32-ID.
+
 
 MEDM control screens
 ====================
@@ -185,6 +215,21 @@ Example output::
   Press Enter to stop...
   Stopping...
   Stopped. Manual control restored.
+
+On a clean exit (Enter pressed at the prompt), the script's ``finally``
+block stops the waveform generator, disables the trigger input, forces
+``PidLoopMode.CLOSED_LOOP``, and issues a ``move_to_position(0.0)`` on
+each device before closing the Telnet connection. The
+``move_to_position`` call is what actually restores serial-driven
+setpoint control on the controller, so the EPICS IOC (or a subsequent
+Python session) can drive the piezo immediately after the script exits.
+
+If a Python session is killed uncleanly (``kill -9``, crash) and the
+IOC's ``JenaNV200D:jena1:write`` no longer moves the piezo afterwards,
+the controller is stuck in waveform / trigger-driven mode. Recover by
+re-running ``nv200_trigger_step.py`` and pressing Enter immediately
+(so the ``finally`` block runs), or by opening a short Python session
+that calls ``dev.move_to_position(0.0)`` on each controller.
 
 .. note::
 


### PR DESCRIPTION
## Summary

While bringing up the `JenaNV200D` EPICS IOC at 32-ID (against the same physical piezo controllers that used to live at 2-BM), two non-obvious behaviours of the `nv200` Python library turned out to be worth documenting on the 2-BM side too. This PR adds the corresponding note
s to `docs/source/ops/item_028.rst` (Jena NV200D operation page). No code changes, no new pages, no image additions — just two sections gain explanatory text.

## Changes

Single file: `docs/source/ops/item_028.rst`.

### 1. `Device configuration` — added a warning about the flow-control side effect

Existing instruction still holds ("controllers must be set to `Xon/Xoff` (software) flow control … for the EPICS support to work correctly"), but the `nv200` Python library calls `configure_flow_control(XON_XOFF_PASS_TO_HOST)` on connect when `auto_adjust_comm_params=True` (i
ts default) — this is a **persistent NVM write** to the XPort. If anyone runs `nv200_trigger_step.py` (or any library-based script) with defaults, the XPort silently flips from `Flow 01` to `Flow 05`, replies come framed with XOFF/XON bytes, and the shared stream proto fails 
to parse them. EPICS `read` records then sit at `SEVR=INVALID`, `STAT=CALC` even though `write` still forwards to the controller. The warning explains this failure mode and lists the two options for recovery:

- Reset the XPort back to `Xon/Xoff` via the web UI (fragile — next default Python run breaks it again).
- Install a local proto override at `iocBoot/iocJenaNV200D/JenaNV100D.proto` that accepts the framed reply (the approach used at 32-ID; concrete diff is in the 32-ID docs).

### 2. `Triggered step mode` — described what the script's cleanup actually does

The example output shows `Stopped. Manual control restored.` but doesn't explain what "restored" means. Added a short paragraph noting that on clean exit the `finally` block stops the waveform generator, disables the trigger input, forces `PidLoopMode.CLOSED_LOOP`, and issues
 `move_to_position(0.0)` on each device before closing — and that the `move_to_position` call in particular is what restores serial-driven setpoint control (otherwise the controller stays in waveform mode and the EPICS IOC's `set,X` commands are silently ignored). Also added 
a recovery note for when a Python session is killed uncleanly before the `finally` runs.

The 2-BM copy of `nv200_trigger_step.py` was patched (via `scp`) at the same time this documentation was written, so the described behaviour matches what the script now does. Both `pid.set_mode(CLOSED_LOOP)` and `move_to_position(0.0)` calls are in the `finally` block on both
 32-ID and 2-BM copies.

## Background — how these surfaced

At 32-ID, after installing the IOC, tweaking the piezo from MEDM did nothing, `read` never updated, and `SEVR` was pinned at `INVALID`. Root cause turned out to be the XPort's `Flow 05` state (Item 1 above). After that was fixed with a local proto override, a follow-up sympto
m appeared: `caput JenaNV200D:jena1:write 5.0` produced no motion, `read` hovered near 0. Root cause was the incomplete Python-script cleanup (Item 2 above). The 32-ID docs already carry the same explanations; this PR mirrors the load-bearing bits into the 2-BM page so a futu
re site engineer here doesn't rediscover them.

## Not included in this PR

- No image additions.
- No changes to `procedures/item_013.rst` — the 2-BM version already correctly instructs stopping the IOC before running the script and mentions `Stopped. Manual control restored.` on exit, which is still accurate.
- No fix for the double-colon typo in `iocBoot/iocJenaNV200D/substitutions/JenaNV200D.substitutions` at 2-BM (`$(P):jena1:write` → resolves to `JenaNV200D::jena1:write`; genTweak tweak buttons therefore write to a non-existent PV). That's a code-side fix on the IOC install, n
ot a docs change, and can be applied independently. Not observed in production because the 2-BM workflow uses direct `caput` to `:write` rather than the tweak buttons.

## Test plan

- [ ] `make html` under `docs/` builds without warnings on `ops/item_028.rst`.
- [ ] The new warning box under `Device configuration` renders correctly.
- [ ] The new paragraphs under `Triggered step mode` render below the example-output code block, before the existing EEPROM note.
txmthree% 

