### PR TITLE
Add Data Management page + CSS fix for table cell wrapping

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,16 @@
+/* Allow sphinx_rtd_theme tables (list-table / grid-table) to wrap cell content
+   so long text does not overflow into adjacent columns. */
+.wy-table-responsive table td,
+.wy-table-responsive table th,
+.rst-content table.docutils td,
+.rst-content table.docutils th {
+    white-space: normal !important;
+    vertical-align: top !important;
+}
+
+/* Inline code inside table cells should also wrap when the row is narrow. */
+.wy-table-responsive table code,
+.rst-content table.docutils code {
+    white-space: normal !important;
+    word-break: break-all;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,8 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
+html_css_files = ['custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Content
    source/manual
    source/ops
    source/procedures
+   source/data_management
    source/maxiv
    source/pre_apsu/pre_apsu
    source/publications

--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -1,0 +1,124 @@
+===============
+Data Management
+===============
+
+This page summarizes the DM (APS Data Management) status for 2-BM datasets.
+
+Convention: **Done** means the dataset was permanently moved from ``/local2/2BM``,
+``/data2/2BM``, or ``/data3/2BM`` to ``/gdata/dm/2BM`` and the original copies were
+deleted. **Pending** means the dataset still lives on one of the local disks and
+has not yet been fully archived.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+Done — permanently on DM
+========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Dataset
+     - Size
+     - Removed from
+     - DM location
+   * - ``2026-03-Li-1018528`` (trimmed h5)
+     - 378 G
+     - /data2/2BM/2026-03/2026-03-Li-1018528_rec/
+     - /gdata/dm/2BM/2026-03/2026-03-Li-1018528/analysis/
+   * - ``2026-07-Boyer-0``
+     - 3.8 T
+     - /local2/2BM/2026-07-Boyer-0/
+     - /gdata/dm/2BM/2026-07/2026-07-Boyer-0/data/
+   * - ``2026-07-Li-1014288`` (raw + rec)
+     - 58 T
+     - /data2/2BM/2026-07-Li-1014288{,_rec}/
+     - /gdata/dm/2BM/2026-07/2026-07-Li-1014288/{data,analysis}/
+   * - ``2026-07-Nikitin-0`` (raw + rec)
+     - ~12 T
+     - /data3/2BM/2026-07-Nikitin-0{,_rec}/
+     - /gdata/dm/2BM/2026-07/2026-07-Nikitin-0/{data,analysis}/
+   * - ``2026-07-Qiu-1017594`` (raw + rec)
+     - ~28 T
+     - /local2 + /data2/2BM/2026-07-Qiu-1017594{,_rec}/
+     - /gdata/dm/2BM/2026-07/2026-07-Qiu-1017594/{data,analysis}/
+   * - ``2026-08-Haridy-1015116`` (raw + rec)
+     - ~36 T
+     - /local2 + /data2/2BM/2026-08-Haridy-1015116{,_rec}/
+     - /gdata/dm/2BM/2026-08/2026-08-Haridy-1015116/{data,analysis}/
+
+
+Pending — still on local disk, not fully archived
+=================================================
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Dataset / Path
+     - Size
+     - DM status
+     - Action needed
+   * - ``/local2/2BM/2026-07-Liu-0/``
+     - 475 G
+     - all 21 h5 on DM (byte-exact)
+     - safe to ``rm -rf``; frees 475 G
+   * - ``/local2/2BM/2026-07-Nikitin-0/``
+     - 883 G
+     - all 23 h5 on DM (byte-exact)
+     - safe to ``rm -rf``; frees 883 G
+   * - ``/data3/2BM/2026-07-Rippner-1011312``
+     - 5.1 T
+     - **not on DM** — /local2 copy was deleted, so /data3 is the only surviving copy
+     - decide: upload to DM or accept as sole archive
+   * - ``/data3/2BM/2026-07-DeCarlo-0``
+     - 82 G
+     - not on DM (test folder)
+     - assess necessity
+   * - ``/data3/2BM/2026-07-Liu-0`` + ``_rec``
+     - 457 G raw + 2.0 T rec
+     - not fully backed up on DM
+     - upload to DM before delete
+   * - ``/data2/2BM/2026-03/2026-03-Li-1018528`` (raw)
+     - 3.4 T
+     - all 66 h5 on DM (DM has 238 h5 — superset)
+     - safe to ``rm -rf``
+   * - ``/data2/2BM/2026-03/Noemi`` + ``Noemi_rec``
+     - 230 G + 87 G
+     - no DM folder; possible candidate ``/gdata/dm/2BM/2026-02/2026-02-BrainNoemi-0``
+     - manual verification needed
+   * - ``/data2/2BM/2026-07-Boyer-0`` (raw)
+     - 3.8 T
+     - fully on DM (byte-exact)
+     - safe to ``rm -rf``; frees 3.8 T
+   * - ``/data2/2BM/2026-07-Boyer-0_rec``
+     - 149 G
+     - partial; DM ``/analysis`` has 213 GB more content, /data2 has 1 log file variant
+     - safe to ``rm -rf`` (only 879 B log unique to /data2)
+   * - ``/data2/2BM/2026-07-Boyer-0_tmp`` + ``_tmp_rec``
+     - 107 G + 79 G
+     - not verified against DM
+     - assess necessity
+   * - ``/data2/2BM/2026-02`` (Feb 2026 working folder)
+     - 1.5 T
+     - not verified per-dataset
+     - inventory + verify
+   * - ``/data2/2BM/2026-07-Li-1014288_rec_test``
+     - 480 G
+     - scratch/test folder
+     - assess necessity
+   * - ``/data2/2BM/tmp_denose_brain``
+     - 2.5 T
+     - scratch folder
+     - assess necessity
+   * - ``/data2/2BM/brain_beta`` + ``brain_delta``
+     - 316 G + 633 G
+     - not verified against DM
+     - assess
+   * - ``/data2/2BM/test``, ``/data2/2BM/test2``, ``/data2/2BM/2025-06``, ``/data2/2BM/2025-12``
+     - < 130 G combined
+     - test/old
+     - clean-up candidates


### PR DESCRIPTION
- New docs/source/data_management.rst summarizing DM archival status (datasets moved to /gdata/dm and pending items still on /data2, /data3)
- Added to top-level toctree in docs/index.rst
- New docs/_static/custom.css to force sphinx_rtd_theme table cells (and inline code) to wrap instead of overflowing into adjacent columns
- Enabled html_static_path + html_css_files in docs/conf.py