### PR TITLE
Data Management: add "Confirm to move" column with mailto approval links

### DIFF
--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -64,8 +64,8 @@ Pending — still on local disk, not fully archived
    delete. Click the link to send a pre-filled approval email to Francesco
    De Carlo (decarlo@anl.gov). If your browser has no email client
    configured, copy the path/size info from the row and send it via Slack
-   or any other channel instead. The dataset will be removed once approval
-   is received.
+   or any other channel instead. The dataset will be moved to DM once
+   approval is received.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Each Pending row that is verified byte-exact on DM now includes an "approve →" mailto: link to decarlo@anl.gov with a pre-filled subject and body describing the dataset. Rows still needing verification or DM upload show — instead.

Added a note above the table explaining the workflow, including a fallback for users whose browser has no email client configured (send the info via Slack instead).

The 2-BM edit also updates the note wording ("will be moved to DM once approval is received").