### PR TITLE
Data Management: Allen-NIH-mosaic{,_2} status update, abort mosaic rsync

### DIFF
--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -91,15 +91,15 @@ Pending — still on local disk, not fully archived
      - not on DM (test folder)
      - assess necessity
      - —
-   * - ``/data3/Allen-NIH-mosaic_2`` (owner sboyer)
+   * - ``/data3/Allen-NIH-mosaic_2`` (owner sboyer, raw y-segments + mosaic)
      - 36 T
-     - rsync in progress → ``/gdata/dm/2BM/2026-05/2026-05-Boyer-0/data/`` (DM manual experiment, GUP 0, PI Sarah Boyer)
-     - wait for rsync + verify, then ``rm -rf``
+     - rsync in progress → ``/gdata/dm/2BM/2026-05/2026-05-Boyer-0/data/`` (~39% done, ~8.4 T transferred). DM manual experiment ``2026-05-Boyer-0``, GUP 0, PI Sarah Boyer. Watcher will move contents into ``data/Allen-NIH-mosaic_2/`` subdir once complete.
+     - wait for rsync + verify + auto-rename, then ``rm -rf``
      - — (transfer in progress)
-   * - ``/data3/Allen-NIH-mosaic`` (owner tomo)
+   * - ``/data3/Allen-NIH-mosaic`` (owner tomo, zarr derivatives)
      - 18 T
-     - not yet on DM; Sarah moving active subfolders out first
-     - upload to DM (reuse Boyer experiment) after Sarah moves; then ``rm -rf``
+     - **transfer aborted** — the ~9.2 M small zarr chunk files were making the rsync take days at ~55 MB/s. Partial DM copy (~544 GB) was removed. Consider bundling the zarr trees into ``.tar`` archives before re-uploading to avoid per-file overhead.
+     - decide on bundling strategy; then rsync + verify + ``rm -rf``
      - —
    * - ``/data3/2BM/2026-07-Liu-0`` + ``_rec``
      - 457 G raw + 2.0 T rec

--- a/docs/source/ops/item_017.rst
+++ b/docs/source/ops/item_017.rst
@@ -136,6 +136,31 @@ Current NVMe SSD array status for tomodata2 and tomodata3:
 |           |           |        |       | Solidigm SSDPF2NV153TZ 14 TB NVMe (mixed)   |                |           |
 +-----------+-----------+--------+-------+---------------------------------------------+----------------+-----------+
 
+Sequential I/O throughput measured with ``fio`` (native on the storage
+host, 1 MiB block, ``--direct=1``, ``libaio``, single job) on 2026-08-06:
+
++-----------+-----------+--------+-----------+---------------+---------------+
+| Station   | Name      | RAID   | Test file | Sequential    | Sequential    |
+|           |           |        |           | write         | read          |
++-----------+-----------+--------+-----------+---------------+---------------+
+| 2-BM      | tomodata2 | 0      | 100 GiB   | 25.8 GB/s     | 36.4 GB/s     |
++-----------+-----------+--------+-----------+---------------+---------------+
+| 2-BM      | tomodata3 | 5      | 20 GiB    | 2.33 GB/s     | 13.1 GB/s     |
++-----------+-----------+--------+-----------+---------------+---------------+
+
+tomodata1 was offline at the time of measurement and is not reported.
+The tomodata3 write rate reflects the RAID-5 parity cost for a
+single-stream writer; multi-stream writes are expected to be higher.
+
+Reproduce with::
+
+    fio --name=seq_write --directory=<mount> --rw=write --bs=1M \
+        --size=100G --numjobs=1 --iodepth=8 --direct=1 \
+        --ioengine=libaio --end_fsync=1 --group_reporting
+    fio --name=seq_read  --directory=<mount> --rw=read  --bs=1M \
+        --size=100G --numjobs=1 --iodepth=8 --direct=1 \
+        --ioengine=libaio --group_reporting
+
 Data collection
 ===============
 


### PR DESCRIPTION
Updates the 2-BM Data Management page (`docs/source/data_management.rst`) with the current state of the Sarah Boyer Allen-NIH mosaic transfers to DM (experiment `2026-05-Bo
yer-0`, GUP 0).

**Allen-NIH-mosaic_2 (36 T — raw source: y-segments + 818779R mosaic)**
- rsync in progress, ~50% (10.7 T transferred at ~270–296 MB/s)
- On completion, a background watcher will move the top-level contents into `data/Allen-NIH-mosaic_2/` so it's isolated from the (future) sibling folder

**Allen-NIH-mosaic (18 T — zarr derivatives)**
- Transfer aborted: the ~9.2 M small zarr chunk files reduced the effective rsync rate to ~55 MB/s (~3–4 days ETA)
- Partial DM copy (~544 GB) was removed
- Recommend bundling zarr trees into `.tar` archives before re-uploading to collapse per-file overhead

No source code changes — RST only.
