### PR TITLE
Data Management: Allen-NIH-mosaic{,_2} outcome + 2026-03-Li-1018528 raw to Done

### DIFF
--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -102,8 +102,8 @@ Pending — still on local disk, not fully archived
      - — (transfer in progress)
    * - ``/data3/Allen-NIH-mosaic`` (owner tomo, zarr derivatives)
      - 18 T
-     - **transfer aborted** — the ~9.2 M small zarr chunk files were making the rsync take days at ~55 MB/s. Partial DM copy (~544 GB) was removed. Consider bundling the zarr trees into ``.tar`` archives before re-uploading to avoid per-file overhead.
-     - decide on bundling strategy; then rsync + verify + ``rm -rf``
+     - **not backed up to DM** — derived data (zarr rewrites of the mosaic_2 content); can be regenerated from the DM copy of ``Allen-NIH-mosaic_2`` if ever needed. ~9.2 M small zarr chunk files would take days to rsync; decision was to keep this only on /data3.
+     - no action — keep on /data3 as long as space permits
      - —
    * - ``/data3/2BM/2026-07-Liu-0`` + ``_rec``
      - 457 G raw + 2.0 T rec


### PR DESCRIPTION
Updates the 2-BM Data Management page (`docs/source/data_management.rst`) with recent decisions and completions.

### Allen-NIH-mosaic_2 (36 T — raw source: y-segments + 818779R mosaic)
- rsync in progress noted (now completed 2026-08-07 21:02, 33h 43m at ~305 MB/s avg; on-disk verify = 59,741 / 59,741 byte-exact)
- Watcher moved contents into `data/Allen-NIH-mosaic_2/` subdir automatically

### Allen-NIH-mosaic (18 T — zarr derivatives)
- Transfer aborted: ~9.2 M small zarr chunk files reduced effective rsync rate to ~55 MB/s (~3–4 days ETA)
- Partial DM copy (~544 GB) removed
- **Decision: NOT backing up to DM.** These are derived data — can be regenerated from the DM copy of `Allen-NIH-mosaic_2` if ever needed. Kept only on /data3.

### 2026-03-Li-1018528 raw (3.4 T)
- Was already deleted from `/data2/2BM/2026-03/`; row moved from Pending to Done. DM at `/gdata/dm/2BM/2026-03/2026-03-Li-1018528/data/` holds the full 476 files (superset o
f the 66 that were on /data2).

Commits included in this PR:
- `304c228` Data Management: Allen-NIH-mosaic{,_2} progress + abort mosaic rsync
- `2f3fd6e` Data Management: 2026-03-Li-1018528 raw moved to Done
- `e5591e2` Data Management: Allen-NIH-mosaic will not be backed up to DM
