### PR TITLE
docs(item_020, ops/item_050): softGlueZynq FPGA-out pin table + item_050 Y-dial history subsection (cora TIME-2/#599, HXP-8/#597)

### DIFF
--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -2507,15 +2507,35 @@ softGlueZynq (PSO → camera trigger)
 :Mounted on: Hutch electronics rack
 :Inputs: PSO output of the Aerotech Ensemble drive that runs the
    rotary ``2bmb:m102``.
-:Outputs: Camera trigger input. Per
-   ``tomoscan/tomoscan_fpga_2bm.py``, the wiring is FLIR Oryx
-   ``Line2`` for the current Oryx 5MP / 31MP cameras; the same
-   module also supports Grasshopper3 (``Line0``) and Adimec
-   (continuous-timed) modes if those cameras are swapped in.
-:Signal path:
+:Outputs: Three physical FPGA output channels are wired to
+   downstream devices (verified at the softGlueZynq patch panel
+   2026-07-28):
+
+   =========  ================  ================================================================
+   FPGA out   softGlue signal   Downstream device / connector
+   =========  ================  ================================================================
+   ``out1``   ``outTrig``       Camera trigger — FLIR Oryx ``Line2`` (Oryx 5MP / 31MP)
+   ``out2``   ``JenaX``         X-axis Piezosystem Jena NV200D ``TRG IN``
+                                (see NV200D block, :ref:`coded-aperture-jena-nv200d-piezo`)
+   ``out3``   ``JenaY``         Y-axis Piezosystem Jena NV200D ``TRG IN``
+   =========  ================  ================================================================
+
+   Per ``tomoscan/tomoscan_fpga_2bm.py``, ``Line2`` is the current
+   Oryx 5MP / 31MP wiring; the same module also supports
+   Grasshopper3 (``Line0``) and Adimec (continuous-timed) modes if
+   those cameras are swapped in.
+:Signal path (camera leg):
    PSO → ``MUX2-1`` (selects raw PSO or ``trigILF``) →
-   ``GateDly 1`` (pulse width / delay; default 100 × 100 ns = 10 µs)
-   → camera trigger.
+   ``GateDly1`` (pulse width / delay; default 100 × 100 ns = 10 µs)
+   → ``outTrig`` softGlue signal → FPGA ``out1`` → FLIR Oryx
+   ``Line2``.
+:Signal path (piezo legs):
+   ``outTrig`` also feeds the two per-axis piezo GateDly blocks:
+   → ``GateDly-2`` (5 ms delay) → ``JenaX`` → FPGA ``out2`` →
+   X-axis piezo; and → ``GateDly-3`` (5 ms delay) → ``JenaY`` →
+   FPGA ``out3`` → Y-axis piezo. Full delay-setting and
+   pulse-verification workflow in :doc:`../ops/item_060`
+   "Driving the two Jena piezo stages".
 :EPICS prefix: ``2bmbMZ1:SG:``. Key PVs:
 
    ===================================  =========================================================

--- a/docs/source/ops/item_050.rst
+++ b/docs/source/ops/item_050.rst
@@ -205,31 +205,62 @@ To recover:
 
 After a few minutes, the hexapod will restart.
 
-.. warning::
+After reboot, all six hexapod axes are homed automatically as part
+of the reboot procedure — no manual dial adjustment is required.
 
-   After reboot, the hexapod Y stage does not correctly reset its dial
-   position. Follow the procedure below until a permanent fix is in place.
+Per-axis convention: ``user = dial home + OFFSET``. For Y, the dial
+home is 350 and the OFFSET is -350, so the Y user coordinate reads
+zero at Y dial 350. Other axes have their own dial home + OFFSET
+values chosen so their user coordinate at the homed position is
+sensible for the beamline geometry.
 
-After reboot, all motions home correctly (dial position and encoder
+.. note::
+
+   Earlier versions of this page described a "manual dial reset"
+   workflow where the operator had to set the Y dial to 350 by hand
+   after every reboot. That behaviour is **obsolete** — see the
+   *Fixed / obsolete behaviour* subsection below for the
+   historical record, or cora issue
+   `#597 <https://github.com/xmap/cora/issues/597>`__ (HXP-8) for
+   the change record.
+
+
+Fixed / obsolete behaviour
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This subsection preserves the description of a hexapod-reboot
+quirk that has since been fixed. The workflow below is **no
+longer required**; kept here as a reference for anyone
+reading historical logs or comparing against the pre-fix screens.
+
+*Old behaviour (fixed 2026-07-28, cora#597 / HXP-8):* after a
+reboot, all motions homed correctly (dial position and encoder
 readback both zero) **except** for Y. For Y:
 
-- Dial position is reset to zero (red arrow).
-- Encoder readback dial is at 350 (green arrow).
+- Dial position was reset to zero (red arrow).
+- Encoder readback dial was at 350 (green arrow).
 
-Attempting to move Y in this state will trigger a drive error.
+Attempting to move Y in this state would trigger a drive error.
 
-.. figure:: ../img/hexapod_08.png 
+.. figure:: ../img/hexapod_08.png
    :width: 360px
    :align: center
    :alt: hexapod_y_after_reboot
 
-   Hexapod Y after controller reboot
+   Hexapod Y after controller reboot (old behaviour — dial reset
+   to 0 while encoder read 350).
 
-Set the Y dial manually to 350, as shown below:
+The operator then had to set the Y dial manually to 350 before
+any Y move:
 
-.. figure:: ../img/hexapod_09.png 
+.. figure:: ../img/hexapod_09.png
    :width: 360px
    :align: center
    :alt: hexapod_y_dial
 
-   Hexapod Y dial must be manually set to 350 after controller reboot.
+   Hexapod Y dial manually set to 350 after controller reboot
+   (old procedure).
+
+*Current behaviour (since 2026-07-28):* the reboot procedure homes
+Y at 350 and sets the user coordinate to 0 automatically, as
+documented above. No manual dial adjustment is required.


### PR DESCRIPTION
## Summary

Two small documentation improvements landing together, each following up on a recently-answered cora question:

- **`item_020.rst` softGlueZynq block** — new three-row `:Outputs:` table naming which physical FPGA output pin drives which downstream device: `out1` → camera trigger (FLIR Oryx `Line2`); `out2` → X-axis Piezosystem Jena NV200D `TRG IN`; `out3` → Y-axis Piezosystem Jena NV200D `TRG IN`. Verified at the softGlueZynq patch panel 2026-07-28. The former single
 `:Signal path:` field is split into `:Signal path (camera leg):` and `:Signal path (piezo legs):` so the full chain from PSO through `MUX2-1 → GateDly1 → outTrig` → `out1`, plus the piezo branch through `GateDly-2/-3 → JenaX/JenaY → out2/out3`, is readable end to end without leaving the block. Answers cora `TIME-2` (`cora#599`); replaces "outTrig at pin `?
`" guesses with the confirmed mapping.

- **`ops/item_050.rst` post-reboot Y-dial behaviour** — the previous `.. warning::` block described a manual "set Y dial to 350 after reboot" workflow that is no longer required (per cora `HXP-8` / `cora#597`; operator-confirmed 2026-07-28). Replaced with a positive description of the current auto-homing behaviour (`user = dial home + OFFSET`; Y's `dial hom
e = 350`, `OFFSET = -350` → `user = 0`). The old workflow and its two figures (`hexapod_08.png`, `hexapod_09.png`) are preserved as a `Fixed / obsolete behaviour` H3 subsection with dated headers, so historical logs referring to the manual step remain readable in the docs alongside the current behaviour. `pre_apsu/` copy of this page is intentionally untouc
hed (frozen historical record).

## Commits (in order)

| SHA | Subject |
|---|---|
| `51f800b` | `docs(item_020): document all three softGlueZynq FPGA output pins (out1→camera, out2→X piezo, out3→Y piezo)...` |
| `4c5aa7b` | `docs(ops/item_050): document current post-reboot auto-homing behaviour...` |

## Files changed

- `docs/source/manual/item_020.rst` (M) — softGlueZynq block: expanded `:Outputs:` field with the three-pin table + verification date; split `:Signal path:` into camera and piezo legs.
- `docs/source/ops/item_050.rst` (M) — replaced obsolete `.. warning::` block with current-behaviour paragraph + `Fixed / obsolete behaviour` H3 subsection.

No new assets. Both `hexapod_08.png` and `hexapod_09.png` already existed in `docs/source/img/` and are now correctly re-used inside the historical subsection.

## Test plan

- [x] `make clean && make html` builds cleanly on the DECARLO checkout under Sphinx 5.3.0; no new warnings introduced beyond the pre-existing 4 `pre_apsu/ops/*.sh.rst` toctree warnings.
- [x] Both re-used image references (`hexapod_08.png`, `hexapod_09.png`) resolve; captions are re-worded to signal the historical framing.
- [x] The softGlueZynq `:Outputs:` table matches the physical wiring verified at the softGlueZynq patch panel on 2026-07-28 and matches the corrected PV comment fix in `ops/item_028.rst` (commit `a3aa6be`).
- [ ] Reviewer to confirm the sphinx build succeeds on their end.

## Related

- **Cora TIME-2** (`cora#599`) — the softGlueZynq output-pin question that this table answers.
- **Cora HXP-8** (`cora#597`) — recommended dropping the Y-dial-misreset Caution; this PR completes the doc side of that change.
- **Prior session commits** in this arc: `8cbafd6` (`ops/item_060` softGlue how-to), `a3aa6be` (`item_020`/`item_028` FPGA-out↔axis mapping), and `6eb2468` (`item_021` DMM-distance fix). Same operational-alignment sequence; these two additions round out the softGlueZynq and hexapod-reboot docs.
