### PR TITLE
Data Management multi-pass vnikitin transfer + ops/manual doc updates

### DIFF
--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -107,14 +107,14 @@ Pending — still on local disk, not fully archived
      - —
    * - ``/data3/vnikitin`` (Viktor's personal workspace)
      - 57 T
-     - rsync in progress → ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data3/``. DM manual experiment ``2026-08-Nikitin-0``, GUP 0, PI Viktor Nikitin. Started 2026-08-11; ~420 MB/s solo (halved while sibling rsync runs); ETA ~38 h solo.
-     - wait for rsync + verify, then ``rm -rf`` (Viktor approved archival)
-     - — (transfer in progress)
-   * - ``/data2/vnikitin`` (Viktor's active workspace — **INACTIVE items only, ~8.7 T of 14 T**)
-     - 8.7 T
-     - rsync in progress → ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data2/`` (same DM experiment). Started 2026-08-11; only 13 subdirs/files idle for >30 d (``ESRF``, ``ctxl``, ``data_brainY350a_dist1234.h5``, ``Chawla{,_rec}``, ``Y350a{,_noise}``, ``correct_correct3D.txt``, plus 5 empty dirs). ACTIVE items (``20240515``, ``iotest*``, ``tmp``, ``ctxl_rec*``, ``Y350c_rec_new_cubic_deform`` — ~5.3 T combined) are NOT being transferred yet — Viktor still writing.
-     - wait for rsync + verify; then ask Viktor about ACTIVE items before final delete
-     - — (transfer in progress)
+     - **fully on DM** — 398,021 files byte-exact under ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data3/``. DM manual experiment ``2026-08-Nikitin-0``, GUP 0, PI Viktor Nikitin. Completed 2026-08-14 06:20 (initial pass on tomo4 died with the host; resumed on tomdet, finished cleanly).
+     - awaiting Viktor's ``rm -rf`` as ``vnikitin`` (data owned by tomo/vnikitin)
+     - — (waiting on Viktor)
+   * - ``/data2/vnikitin`` (Viktor's active workspace — pass 1 done + 2 more passes in progress)
+     - 14 T source (~13 T targeted)
+     - Multi-pass rsync into ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data2/`` (same experiment as ``vnikitin_data3``). **Pass 1 DONE** (8.7 T, 61,036 files: ``ESRF``, ``ctxl``, ``data_brainY350a_dist1234.h5``, ``Chawla{,_rec}``, ``Y350a{,_noise}``, ``correct_correct3D.txt``, + empty dirs). **Pass 2 in progress** (~1.8 T: ``ctxl_rec``, ``ctxl_rec40`` — newly idle >30 d). **Pass 3 in progress** (~2.6 T: ``Y350c_rec_new_cubic_deform``, ``tmp``, ``ctxl_rec60``, ``ctxl_rec40_deform`` — idle 16–20 d, Viktor considers stable). Still ACTIVE and excluded: ``20240515`` (554 G, 3.9 d idle), ``iotest`` (307 G, 7 d), ``iotest_buf_ups1`` (527 G, writing today).
+     - wait for passes 2 + 3 verify; then loop back to Viktor about the remaining ACTIVE items before final delete
+     - — (partial complete, more transfers in progress)
    * - ``/data3/2BM/2026-07-Liu-0`` + ``_rec``
      - 457 G raw + 2.0 T rec
      - fully on DM (raw 20/21 h5 byte-exact, rec 50,016/50,016 files byte-exact)

--- a/docs/source/manual/item_020.rst
+++ b/docs/source/manual/item_020.rst
@@ -931,7 +931,10 @@ is encapsulated by the energy-change IOC; see :ref:`composite-iocs`.
      - Global tank downstream X
      - ``2bma:m28``
    * - DMM DSY
-     - Second crystal Y relative to the first
+     - Downstream tank Y (in-beam / retracted at mode switch;
+       constant within each mode — see the tank / alignment sub-block
+       below). NOT a second-crystal fine motor; that role belongs to
+       ``M2 Y`` (``2bma:m32``).
      - ``2bma:m29``
    * - DMM US Arm
      - Upstream Bragg-arm rotation
@@ -946,8 +949,16 @@ is encapsulated by the energy-change IOC; see :ref:`composite-iocs`.
 The tank's upstream end carries two independent Y motors (``USY OB``
 and ``USY IB``); their average sets the upstream tank Y position and
 their difference produces a Z-tilt around the beam axis. The second
-crystal is positioned relative to the first via the ``DSY`` (Y),
-``M2 Z`` (along beam), and ``M2 Y`` motors.
+crystal is positioned relative to the first via the along-beam
+translation ``M2 Z`` (``2bma:m8``) and the fine vertical ``M2 Y``
+(``2bma:m32``) — the per-energy Bragg-tracking motors that sweep
+with energy in Mono mode (see the per-energy saved-position sub-block
+below and `ENERGY-1 (cora#249) <https://github.com/xmap/cora/issues/249>`__
+for the numeric table). ``DSY`` (``2bma:m29``) is NOT part of this
+crystal-fine positioning — it is a downstream tank Y that only
+switches between in-beam (``0``) and retracted (``-10``) at mode
+change; see the tank / alignment sub-block below and
+`ENERGY-5 (cora#254) <https://github.com/xmap/cora/issues/254>`__.
 
 **Tank / alignment motors (energy-independent within mode).** The
 five DMM tank-positioning motors (``2bma:m25-m29``) are part of the

--- a/docs/source/ops/item_018.rst
+++ b/docs/source/ops/item_018.rst
@@ -232,6 +232,51 @@ To list all tasks::
   (dm-user) [2bmb@arcturus]$ dm-list-archive-tasks
 
 
+Scan-file ``/process/acquisition/start_date`` provenance
+========================================================
+
+Starting 2026-08-13, ``/process/acquisition/start_date`` in every scan
+HDF5 file at 2-BM is written by the tomoscan client
+(`decarlof/tomoscan@d0025a2
+<https://github.com/decarlof/tomoscan/commit/d0025a233059a4b51af34b5025a98b7dfca4a686>`__
+and later) in ``end_scan()`` via ``h5py``, using the Python-captured
+scan-start timestamp. ``/process/acquisition/end_date`` remains
+areaDetector-written via the HDF5 plugin's ``when="OnFileClose"``
+layout entry and was correct throughout.
+
+Scan files written **before** the fix carry a stale ``start_date`` that
+reflects the previous scan's last-frame time. The mechanism was an
+``EPICS_PV`` NDAttribute + ``when="OnFileOpen"`` race in the
+areaDetector plugin chain: the NDAttribute plugin snapshot only
+refreshes when an NDArray flows through, and no NDArray of the current
+scan exists yet at file-open time, so the ``start_date`` dataset was
+populated with the plugin cache's frozen last-frame value from the
+previous scan. Skew ranged from seconds (short inter-scan gap) to
+days (long idle); a 9-hour offset was directly observed on 2026-08-12.
+
+For pre-fix files, read the corrected value via ``meta show``
+(`xray-imaging/meta-cli@29a56bc
+<https://github.com/xray-imaging/meta-cli/commit/29a56bc3d5bc788f1325a0937185ec496d241cb9>`__
+and later), which computes it as ``end_date - (num_angles *
+acquire_period + num_dark * exposure + num_flat * flat_exposure_time
++ 30 s overhead)`` and displays it with a ``[derived]`` suffix. The
+on-disk value is left as-is for provenance; the correction is display-
+only at read time.
+
+The IOC-side removal of the buggy NDAttribute + layout entry lives at
+`data-exchange/dxfile@de33f3a
+<https://github.com/data-exchange/dxfile/commit/de33f3a2da7de49f116be021d734890c608b51d6>`__,
+deployed via the working tree at ``/home/beams/2BMB/conda/dxfile/`` (
+symlinked into the 2bmbSP2 IOC boot dir at
+``/net/s2dserv/xorApps/epics/PreBuilts/2bmbSP2/iocBoot/ioc2bmbSP2/``);
+the IOC was restarted 2026-08-13 to pick up the change.
+
+Details, three-repo fix summary, and CORA impact:
+`cora#655 <https://github.com/xmap/cora/issues/655>`__ and
+`tomography/tomoscan#180
+<https://github.com/tomography/tomoscan/issues/180>`__.
+
+
 Add users
 =========
 


### PR DESCRIPTION
Bundles all commits on `decarlof/2bm-docs:master` since the last merge into `xray-imaging/2bm-docs:master`. Two independent workstreams.

### Data Management (docs/source/data_management.rst)

- **`/data3/vnikitin`** (57 T) — DM upload complete 2026-08-14 06:20 (16h 34m from the tomdet resume; the initial tomo4 run died with the host). All 398,021 files byte-exact under `/
gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data3/`.
- **`/data2/vnikitin`** — multi-pass rsync into `data/vnikitin_data2/` of the same experiment. Pass 1 (~8.7 T inactive items) done; passes 2 (`ctxl_rec`, `ctxl_rec40` — 1.8 T) and 3 
(`Y350c_rec_new_cubic_deform`, `tmp`, `ctxl_rec60`, `ctxl_rec40_deform` — 2.6 T) in flight. Still-active items excluded (`20240515`, `iotest`, `iotest_buf_ups1`).
- Prior touch-ups on Allen-NIH-mosaic{,_2} status (transfer/verify/rename outcome; decision that the zarr sibling won't be archived), `2026-03-Li-1018528` raw moved from Pending to D
one.

### Ops / manual updates (from parallel doc work on another workstation)

- `docs(ops/item_018)`: document `/process/acquisition/start_date` provenance and pre/post-fix behaviour (cora #655 / DATA-8, tomography/tomoscan #180).
- `docs(item_020)`: correct DMM DSY / M2 Y motor-role descriptions per ENERGY-5 / ENERGY-1 findings.
- `docs(ops/item_050)`: document current post-reboot auto-homing behaviour; move manual Y-dial-reset workflow into a "Fixed / obsolete" subsection.
- `docs(item_020)`: document all three softGlueZynq FPGA output pins (out1→camera, out2→X piezo, out3→Y piezo).

RST + one small config change; no source code changes.
