### PR TITLE
Data Management: staff/project backup consolidation + Liu-0 moved to Done

### DIFF
--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -111,22 +111,22 @@ Pending — still on local disk, not fully archived
      - —
    * - ``/data3/Allen-NIH-mosaic_2`` (owner sboyer, raw y-segments + mosaic)
      - 36 T
-     - **fully on DM** — 59,741/59,741 files byte-exact under ``/gdata/dm/2BM/2026-05/2026-05-Boyer-0/data/Allen-NIH-mosaic_2/``. DM manual experiment ``2026-05-Boyer-0``, GUP 0, PI Sarah Boyer. rsync completed 2026-08-07 21:01 (33h 43m at ~305 MB/s avg).
+     - **fully on DM** — 59,741/59,741 files byte-exact under ``/gdata/dm/2BM/2026-05/2026-05-Boyer-0/data/Allen-NIH-mosaic_2/``. Also being re-rsynced fresh into ``2026-08-ImagingStaff-0/data/data3/Allen-NIH-mosaic_2/`` (queued, see *Shared staff/project backup* below); Boyer-0 will be retired once ImagingStaff verifies.
      - awaiting Sarah to ``rm -rf`` as ``sboyer`` (files owned by her)
      - — (waiting on Sarah)
    * - ``/data3/Allen-NIH-mosaic`` (owner tomo, zarr derivatives)
      - 18 T
-     - **not backed up to DM** — derived data (zarr rewrites of the mosaic_2 content); can be regenerated from the DM copy of ``Allen-NIH-mosaic_2`` if ever needed. ~9.2 M small zarr chunk files would take days to rsync; decision was to keep this only on /data3.
+     - **not backed up to DM — explicitly excluded from ImagingStaff** — derived data (zarr rewrites of the mosaic_2 content); regenerable from the DM copy of ``Allen-NIH-mosaic_2``. ~9.2 M small zarr chunk files would take days to rsync; decision was to keep this only on /data3.
      - no action — keep on /data3 as long as space permits
      - —
    * - ``/data3/vnikitin`` (Viktor's personal workspace)
      - 57 T
-     - **fully on DM** — 398,021 files byte-exact under ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data3/``. DM manual experiment ``2026-08-Nikitin-0``, GUP 0, PI Viktor Nikitin. Completed 2026-08-14 06:20 (initial pass on tomo4 died with the host; resumed on tomdet, finished cleanly).
+     - **fully on DM** — 398,021 files byte-exact under ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data3/``. DM manual experiment ``2026-08-Nikitin-0``, GUP 0, PI Viktor Nikitin. Completed 2026-08-14 06:20 (initial pass on tomo4 died with the host; resumed on tomdet, finished cleanly). **Also being re-rsynced fresh** into ``2026-08-ImagingStaff-0/data/data3/vnikitin/`` (queued, see *Shared staff/project backup* below); Nikitin-0 will be retired once ImagingStaff verifies.
      - awaiting Viktor's ``rm -rf`` as ``vnikitin`` (data owned by tomo/vnikitin)
      - — (waiting on Viktor)
    * - ``/data2/vnikitin`` (Viktor's active workspace)
      - 14 T source, **~13 T saved / ~1.4 T LOST**
-     - All 3 rsync passes completed before crash; ~13 T (61,036 files pass 1 + 166 files pass 2 + 119,371 files pass 3) safely under ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data2/``. **LOST on 2026-08-14**: active items excluded from rsync — ``20240515`` (554 G), ``iotest`` (307 G), ``iotest_buf_ups1`` (527 G), plus ``tmp/t_test.h5`` (157 MB, appeared during pass 3 scan).
+     - All 3 rsync passes completed before crash; ~13 T (61,036 files pass 1 + 166 files pass 2 + 119,371 files pass 3) safely under ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data2/``. **LOST on 2026-08-14**: active items excluded from rsync — ``20240515`` (554 G), ``iotest`` (307 G), ``iotest_buf_ups1`` (527 G), plus ``tmp/t_test.h5`` (157 MB, appeared during pass 3 scan). **Nikitin-0 copy currently being DM→DM folded** into ``2026-08-ImagingStaff-0/data/data2/vnikitin/`` (Stream B, see *Shared staff/project backup* below).
      - no action; Viktor already notified of the lost active items
      - N/A — /data2 gone
    * - ``/data2/2BM/2026-07-Boyer-0`` (raw)
@@ -139,6 +139,103 @@ Pending — still on local disk, not fully archived
      - **on DM** (all but a 879 B log) — /data2 source LOST 2026-08-14; DM ``/analysis`` unaffected.
      - none — DM is authoritative
      - N/A — /data2 gone
+
+Shared staff/project backup — ``2026-08-ImagingStaff-0``
+========================================================
+
+Started **2026-08-18** to consolidate all non-beamline dirs on ``/data3`` (and
+later ``/data2`` once IT clears it after the 2026-08-14 failure) into a single
+yearly shared DM experiment. Purpose: provide DM archival for staff personal
+workspaces (sboyer, vnikitin, etc.) and cross-cutting project dirs (ESRF,
+Allen-NIH-\*, TMP_\*) that don't fit under a beamline GUP. **Yearly rollover:**
+this experiment covers Aug–Dec 2026; a fresh ``2027-01-ImagingStaff-0`` will
+be created in January.
+
+.. note::
+
+   **ACL widening.** ``2026-08-ImagingStaff-0`` grants read/write to all 9
+   imaging group staff badges (Fezzaa, Kastengren, Shevchenko, Clark, Boyer,
+   Mittone, Tang, Ekmekci, De Carlo). This is wider than the per-user rescue
+   experiments (``2026-08-Nikitin-0``, ``2026-05-Boyer-0``) which will be
+   retired once ImagingStaff verifies. Sarah and Viktor have been notified.
+
+Execution: **two parallel streams**
+
+- **Stream A (serial):** fresh rsyncs from ``/data3`` → ``ImagingStaff/data/data3/``
+  for all live sources. One item at a time, ~350 MB/s per stream.
+- **Stream B (side channel):** DM→DM copy of ``Nikitin-0/data/vnikitin_data2/`` →
+  ``ImagingStaff/data/data2/vnikitin/`` (only surviving copy of the destroyed
+  /data2/vnikitin workspace). Runs on a different NFS server than Stream A, no
+  bandwidth contention, ~570 MB/s.
+
+All rsyncs use ``rsync -rt --partial --info=progress2 --stats --chmod=Dg+w --exclude='.Trash-*'``.
+The ``--chmod=Dg+w`` flag keeps new dirs group-writable so the ACL mask stays
+``rwx`` and future delta rsyncs don't hit "mkstemp Permission denied" errors on
+tight-mask subdirs.
+
+Current status (as of 2026-08-18 20:47)
+---------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Source
+     - Size
+     - DM destination under ``2026-08-ImagingStaff-0/``
+     - Status
+   * - ``/data3/sboyer``
+     - 31 T
+     - ``data/data3/sboyer/``
+     - **IN PROGRESS** (Stream A, first item, ETA ~8h)
+   * - ``/data3/sboyer_rec``
+     - 1.2 T
+     - ``data/data3/sboyer_rec/``
+     - Stream A, queued
+   * - ``/data3/vnikitin``
+     - 57 T
+     - ``data/data3/vnikitin/``
+     - Stream A, queued (biggest single item, ETA ~1.5 days once started)
+   * - ``/data3/Allen-NIH-mosaic_2``
+     - 36 T
+     - ``data/data3/Allen-NIH-mosaic_2/``
+     - Stream A, queued
+   * - ``/data3/ESRF``
+     - ?
+     - ``data/data3/ESRF/``
+     - Stream A, queued
+   * - ``/data3/TMP_BRAIN_ESRF``
+     - ?
+     - ``data/data3/TMP_BRAIN_ESRF/``
+     - Stream A, queued
+   * - ``/data3/TMP_YALE``
+     - ? (large dir, many files)
+     - ``data/data3/TMP_YALE/``
+     - Stream A, queued
+   * - ``Nikitin-0/data/vnikitin_data2/`` (DM→DM)
+     - 13 T
+     - ``data/data2/vnikitin/``
+     - **IN PROGRESS** (Stream B, ETA ~5h)
+   * - ``/data3/Allen-NIH-mosaic`` (18 T zarr)
+     - 18 T
+     - — (**excluded**)
+     - regenerable from Allen-NIH-mosaic_2; keep on /data3 only
+
+Estimated total wall-clock: **4–5 days** (Stream A serialized, ~163 T at ~350 MB/s).
+
+Notes
+-----
+
+- ``/data2`` is essentially empty after the 2026-08-14 tomodata2 failure. IT is
+  still investigating BIOS-level issues. Once /data2 is cleared and staff
+  repopulate it, delta rsyncs into ``ImagingStaff/data/data2/`` will pick up
+  the new content.
+- After ImagingStaff verifies clean, ``2026-08-Nikitin-0`` and
+  ``2026-05-Boyer-0`` will be retired (via dmadmin, not ``rm -rf``, to avoid
+  orphaning DM metadata). Their content will exist only under ImagingStaff.
+- Refresh cadence: quarterly delta rsyncs from ``/data2`` + ``/data3`` into the
+  current year's experiment. No ``--delete`` — DM keeps history of anything
+  users removed since last snapshot.
 
 Lost to 2026-08-14 tomodata2 failure
 ====================================

--- a/docs/source/data_management.rst
+++ b/docs/source/data_management.rst
@@ -51,6 +51,10 @@ Done — permanently on DM
      - 58 T
      - /data2/2BM/2026-07-Li-1014288{,_rec}/
      - /gdata/dm/2BM/2026-07/2026-07-Li-1014288/{data,analysis}/
+   * - ``2026-07-Liu-0`` (raw + rec)
+     - ~2.5 T (457 G + 2.0 T)
+     - /data3/2BM/2026-07-Liu-0{,_rec}/
+     - /gdata/dm/2BM/2026-07/2026-07-Liu-0/{data,analysis}/ *(3 JPG snapshots ~940 KB unique to /data3 not archived)*
    * - ``2026-07-Nikitin-0`` (raw + rec)
      - ~12 T
      - /data3/2BM/2026-07-Nikitin-0{,_rec}/
@@ -125,11 +129,6 @@ Pending — still on local disk, not fully archived
      - All 3 rsync passes completed before crash; ~13 T (61,036 files pass 1 + 166 files pass 2 + 119,371 files pass 3) safely under ``/gdata/dm/2BM/2026-08/2026-08-Nikitin-0/data/vnikitin_data2/``. **LOST on 2026-08-14**: active items excluded from rsync — ``20240515`` (554 G), ``iotest`` (307 G), ``iotest_buf_ups1`` (527 G), plus ``tmp/t_test.h5`` (157 MB, appeared during pass 3 scan).
      - no action; Viktor already notified of the lost active items
      - N/A — /data2 gone
-   * - ``/data3/2BM/2026-07-Liu-0`` + ``_rec``
-     - 457 G raw + 2.0 T rec
-     - fully on DM (raw 20/21 h5 byte-exact, rec 50,016/50,016 files byte-exact)
-     - safe to ``rm -rf``; frees ~2.5 T
-     - `approve → <mailto:decarlo@anl.gov?subject=DM%20delete%20approval%3A%20%2Fdata3%2F2BM%2F2026-07-Liu-0%20and%20_rec&body=I%20approve%20deletion%20of%20%2Fdata3%2F2BM%2F2026-07-Liu-0%20and%20%2Fdata3%2F2BM%2F2026-07-Liu-0_rec%20(~2.5%20T%2C%20fully%20on%20DM%20byte-exact).>`__
    * - ``/data2/2BM/2026-07-Boyer-0`` (raw)
      - 3.8 T
      - **on DM** — verified byte-exact before crash. /data2 source LOST 2026-08-14 but DM copy at ``/gdata/dm/2BM/2026-07/2026-07-Boyer-0/data/`` is intact.


### PR DESCRIPTION
Updates the `Data Management` page (`docs/source/data_management.rst`) with:

1. **New "Shared staff/project backup" section** documenting the
   `2026-08-ImagingStaff-0` DM experiment created 2026-08-18 to consolidate
   all non-beamline dirs on `/data3` (and later `/data2` once IT clears it
   after the 2026-08-14 failure) into a single yearly shared experiment.
   - Yearly rollover convention (`2027-01-ImagingStaff-0` in January)
   - ACL widening note (9 imaging group staff badges, wider than the
     per-user rescue experiments Nikitin-0 / Boyer-0 which will be retired
     once consolidation verifies; Sarah and Viktor have been notified)
   - Two-stream execution plan (Stream A: serial fresh rsyncs from
     `/data3`; Stream B: DM→DM copy of the one path with no live source —
     `Nikitin-0/data/vnikitin_data2` — into `ImagingStaff/data/data2/vnikitin`)
   - Per-item status table with current progress markers
   - Rsync flags note (`--chmod=Dg+w` needed to prevent ACL-mask lockout
     on future delta rsyncs)

2. **Liu-0 moved from Pending to Done.**
   - `/data3/2BM/2026-07-Liu-0` (457 G raw) + `_rec` (2.0 T) deleted after
     verification against `/gdata/dm/2BM/2026-07/2026-07-Liu-0/{data,analysis}/`
   - Footnote about 3 disposable JPG snapshots (~940 KB total, regenerable)
     that were not archived to DM

3. **Cross-references added** to 4 existing Pending rows for entries
   affected by the ImagingStaff consolidation:
   - `/data3/Allen-NIH-mosaic_2` — now also being re-rsynced fresh into
     `ImagingStaff/data/data3/Allen-NIH-mosaic_2/` (Boyer-0 will be retired)
   - `/data3/Allen-NIH-mosaic` — explicitly excluded from ImagingStaff
     (18 T zarr, regenerable from mosaic_2)
   - `/data3/vnikitin` — also being re-rsynced fresh into
     `ImagingStaff/data/data3/vnikitin/` (Nikitin-0 will be retired)
   - `/data2/vnikitin` — Nikitin-0 copy currently being DM→DM folded into
     `ImagingStaff/data/data2/vnikitin/`

### Test plan

- [x] `sphinx-build` renders the new section without errors (RST tables
      use `:widths: auto`, matches existing convention; `_static/custom.css`
      already handles cell wrapping)
- [x] All cross-references resolve (no undefined roles / labels)
- [x] Existing Pending row edits preserve list-table structure
- [ ] Verify on ReadTheDocs build once merged

