### PR TITLE
Links: move Useful Links and Mailing list to their own page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,34 +27,10 @@ Content
    source/maxiv
    source/pre_apsu/pre_apsu
    source/publications
+   source/links
 
 Contribute
 ----------
 
 * `Documentation <https://github.com/xray-imaging/2bm-docs/tree/master/docs>`_
 * `Issue Tracker <https://github.com/xray-imaging/2bm-docs/issues>`_
-
-Mailing list
-------------
-
-To subscribe to the 2-BM mailing list send an e-mail to 2-bm-owner@lists.anl.gov. 
-
-Mailing list administrators can configure the mailing list `here <https://lists-web.anl.gov/mailman3/lists/2-bm.lists.anl.gov/>`_.
-
-
-Useful Links
-------------
-
-
-
-`User login <https://ups.servicenowservices.com/ups>`_
-
-`Admin loging <https://ups.servicenowservices.com/login_locate_sso.do>`_ then enter your anl email address
-
-`Credit for Sector Orientation <https://beam.aps.anl.gov/pls/apsweb/sst_credit.start_page>`_
-
-`ESAF <https://beam.aps.anl.gov/pls/apsweb/esaf0001.start_page>`_
-
-`Safety and Training <https://www.aps.anl.gov/Safety-and-Training>`_
-
-`Retired APS Beam Time Access System (read only) <https://beam.aps.anl.gov/pls/apsweb/gup0005.start_page>`_

--- a/docs/source/links.rst
+++ b/docs/source/links.rst
@@ -1,0 +1,21 @@
+=====
+Links
+=====
+
+Useful links
+------------
+
+* `User login <https://ups.servicenowservices.com/ups>`_
+* `Admin login <https://ups.servicenowservices.com/login_locate_sso.do>`_ then enter your anl email address
+* `Credit for Sector Orientation <https://beam.aps.anl.gov/pls/apsweb/sst_credit.start_page>`_
+* `ESAF <https://beam.aps.anl.gov/pls/apsweb/esaf0001.start_page>`_
+* `Safety and Training <https://www.aps.anl.gov/Safety-and-Training>`_
+* `2-BM EPICS IOC status <https://bcda.xray.aps.anl.gov/cgi-bin/ioc_alive.cgi?net=10.54.113>`_
+* `Retired APS Beam Time Access System (read only) <https://beam.aps.anl.gov/pls/apsweb/gup0005.start_page>`_
+
+Mailing list
+------------
+
+To subscribe to the 2-BM mailing list send an e-mail to 2-bm-owner@lists.anl.gov.
+
+Mailing list administrators can configure the mailing list `here <https://lists-web.anl.gov/mailman3/lists/2-bm.lists.anl.gov/>`_.


### PR DESCRIPTION
Add source/links to the toctree so Links appears in the left sidebar, and move the Useful Links and Mailing list sections off the home page into docs/source/links.rst, converting the links to a bullet list.

Also add the 2-BM EPICS IOC status link (net=10.54.113) and fix the "Admin loging" typo.